### PR TITLE
Use packer 1.5.4 - latest release

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
   agent {
     docker {
       args '--entrypoint=""'
-      image 'hashicorp/packer:1.5.1'
+      image 'hashicorp/packer:1.5.4'
       label 'docker&&linux'
     }
   }


### PR DESCRIPTION
Packer 1.5.2 includes several changes and bug fixes for Azure.

See release notes:

https://github.com/hashicorp/packer/blob/v1.5.4/CHANGELOG.md