### PR TITLE
Update AMI name to be unique

### DIFF
--- a/aws/ubuntu-18-agent.amd64.json
+++ b/aws/ubuntu-18-agent.amd64.json
@@ -20,7 +20,7 @@
           "most_recent" : true
       },
       "instance_type": "t2.micro",
-      "ami_name": "jenkins-agent-ubuntu18.04-amd64",
+      "ami_name": "jenkins-agent-ubuntu18.04-amd64-{{isotime | clean_resource_name}}",
 
       "tags": {
         "timestamp": "{{isotime \"20060102150405\"}}",

--- a/aws/ubuntu-18-agent.arm64.json
+++ b/aws/ubuntu-18-agent.arm64.json
@@ -20,7 +20,7 @@
           "most_recent" : true
       },
       "instance_type": "a1.medium",
-      "ami_name": "jenkins-agent-ubuntu18.04-arm64",
+      "ami_name": "jenkins-agent-ubuntu18.04-arm64-{{isotime | clean_resource_name}}",
 
       "tags": {
         "timestamp": "{{isotime \"20060102150405\"}}",

--- a/aws/windows-2019-agent.amd64.json
+++ b/aws/windows-2019-agent.amd64.json
@@ -32,7 +32,7 @@
         "most_recent" : true
       },
       "instance_type": "t2.micro",
-      "ami_name": "jenkins-agent-win2019",
+      "ami_name": "jenkins-agent-win2019-{{isotime | clean_resource_name}}",
 
       "tags": {
         "timestamp": "{{isotime \"20060102150405\"}}",

--- a/aws/windows-2019-docker-agent.amd64.json
+++ b/aws/windows-2019-docker-agent.amd64.json
@@ -32,7 +32,7 @@
         "most_recent" : true
       },
       "instance_type": "t2.micro",
-      "ami_name": "jenkins-agent-win2019-docker",
+      "ami_name": "jenkins-agent-win2019-docker-{{isotime | clean_resource_name}}",
 
       "tags": {
         "timestamp": "{{isotime \"20060102150405\"}}",


### PR DESCRIPTION
If the name is not unique, each time we generate a new AMI, a new ID is assigned to the AMI name, and the previous image is not available anymore