### PR TITLE
Update release of Windows Server 2019

### DIFF
--- a/aws/windows-2019-agent.amd64.json
+++ b/aws/windows-2019-agent.amd64.json
@@ -24,7 +24,7 @@
       "source_ami_filter": {
         "filters": {
           "virtualization-type": "hvm",
-          "name": "Windows_Server-2019-English-Core-ContainersLatest-*",
+          "name": "Windows_Server-1909-English-Core-ContainersLatest-*",
           "root-device-type": "ebs"
         },
         "owners": [

--- a/aws/windows-2019-agent.amd64.json
+++ b/aws/windows-2019-agent.amd64.json
@@ -24,7 +24,7 @@
       "source_ami_filter": {
         "filters": {
           "virtualization-type": "hvm",
-          "name": "Windows_Server-1909-English-Core-ContainersLatest-*",
+          "name": "Windows_Server-2004-English-Core-ContainersLatest-*",
           "root-device-type": "ebs"
         },
         "owners": [


### PR DESCRIPTION
This updates the image to Windows Server 2004. This should allow us to build newer Docker images.