### PR TITLE
revert: increase disk size for AWS Windows builder

### DIFF
--- a/aws/windows-2019-agent.amd64.json
+++ b/aws/windows-2019-agent.amd64.json
@@ -24,7 +24,7 @@
       "source_ami_filter": {
         "filters": {
           "virtualization-type": "hvm",
-          "name": "Windows_Server-2019-English-Full-Base-*",
+          "name": "Windows_Server-2019-English-Core-ContainersLatest-*",
           "root-device-type": "ebs"
         },
         "owners": [


### PR DESCRIPTION
Reverts jenkins-infra/packer-images#48

AMI doesn't contain docker/container support