### PR TITLE
chore: move all version properties to build.sh

### DIFF
--- a/aws/ubuntu-18-agent.amd64.json
+++ b/aws/ubuntu-18-agent.amd64.json
@@ -1,7 +1,7 @@
 {
   "variables": {
-    "compose_version": "1.25.4",
-    "maven_version": "3.6.3"
+    "compose_version": "{{user `compose_version`}}",
+    "maven_version": "{{user `maven_version`}}"
   },
   "builders": [
     {

--- a/aws/ubuntu-18-agent.arm64.json
+++ b/aws/ubuntu-18-agent.arm64.json
@@ -1,7 +1,7 @@
 {
   "variables": {
-    "compose_version": "1.25.4",
-    "maven_version": "3.6.3"
+    "compose_version": "{{user `compose_version`}}",
+    "maven_version": "{{user `maven_version`}}"
   },
   "builders": [
     {

--- a/aws/windows-2019-agent.amd64.json
+++ b/aws/windows-2019-agent.amd64.json
@@ -1,10 +1,10 @@
 {
   "variables": {
-    "maven_version": "3.6.3",
-    "git_version": "2.28.0",
-    "jdk11_version": "11.0.8+10",
-    "jdk8_version": "8u265-b01",
-    "git_lfs_version": "2.12.0",
+    "maven_version": "{{user `maven_version`}}",
+    "git_version": "{{user `git_version`}}",
+    "jdk11_version": "{{user `jdk11_version`}}",
+    "jdk8_version": "{{user `jdk8_version`}}",
+    "git_lfs_version": "{{user `git_lfs_version`}}",
     "openssh_version": "v8.1.0.0p1-Beta",
     "image_name": "jenkins-agent-win2019",
     "openssh_public_key": ""

--- a/azure/ubuntu-18-agent.amd64.json
+++ b/azure/ubuntu-18-agent.amd64.json
@@ -1,7 +1,7 @@
 {
   "variables": {
-    "compose_version": "1.25.4",
-    "maven_version": "3.6.3"
+    "compose_version": "{{user `compose_version`}}",
+    "maven_version": "{{user `maven_version`}}"
   },
   "builders": [
     {

--- a/azure/windows-2019-agent.amd64.json
+++ b/azure/windows-2019-agent.amd64.json
@@ -1,10 +1,10 @@
 {
   "variables": {
-    "maven_version": "3.6.3",
-    "git_version": "2.28.0",
-    "jdk11_version": "11.0.8+10",
-    "jdk8_version": "8u265-b01",
-    "git_lfs_version": "2.12.0",
+    "maven_version": "{{user `maven_version`}}",
+    "git_version": "{{user `git_version`}}",
+    "jdk11_version": "{{user `jdk11_version`}}",
+    "jdk8_version": "{{user `jdk8_version`}}",
+    "git_lfs_version": "{{user `git_lfs_version`}}",
     "image_name": "jenkins-agent-win2019"
   },
   "builders": [

--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,13 @@
 : "${ARCHITECTURE:?Architecture not defined[amd64,arm64]}"
 : "${LOCATION:?Location not defined}"
 
+# defining versions here so they can be passed to all builds
+MAVEN_VERSION="3.6.3"
+GIT_VERSION="2.29.2"
+JDK11_VERSION="11.0.9+11"
+JDK8_VERSION="8u272-b10"
+GIT_LFS_VERSION="2.12.1"
+COMPOSE_VERSION="1.25.4"
 
 function isTemplateExist() {
   if [ ! -f "${CLOUD}/${AGENT}-agent.${ARCHITECTURE}.json" ]; then
@@ -23,6 +30,12 @@ function buildAzure(){
       --var subscription_id="$AZURE_SUBSCRIPTION_ID" \
       --var client_id="$AZURE_CLIENT_ID" \
       --var client_secret="$AZURE_CLIENT_SECRET" \
+      --var maven_version="$MAVEN_VERSION" \
+      --var git_version="$GIT_VERSION" \
+      --var jdk11_version="$JDK11_VERSION" \
+      --var jdk8_version="$JDK8_VERSION" \
+      --var git_lfs_version="$GIT_LFS_VERSION" \
+      --var compose_version="$COMPOSE_VERSION" \
       "./${CLOUD}/${AGENT}-agent.${ARCHITECTURE}.json"
 }
 
@@ -33,6 +46,12 @@ function buildAWS(){
       --var aws_access_key="$AWS_ACCESS_KEY_ID" \
       --var aws_secret_key="$AWS_SECRET_ACCESS_KEY" \
       --var openssh_public_key="$OPENSSH_PUBLIC_KEY" \
+      --var maven_version="$MAVEN_VERSION" \
+      --var git_version="$GIT_VERSION" \
+      --var jdk11_version="$JDK11_VERSION" \
+      --var jdk8_version="$JDK8_VERSION" \
+      --var git_lfs_version="$GIT_LFS_VERSION" \
+      --var compose_version="$COMPOSE_VERSION" \
       "./${CLOUD}/${AGENT}-agent.${ARCHITECTURE}.json"
 }
 

--- a/validate-vars.json
+++ b/validate-vars.json
@@ -3,5 +3,11 @@
   "resource_group_name": "packer-images",
   "subscription_id": "invalid",
   "client_id": "invalid",
-  "client_secret": "invalid"
+  "client_secret": "invalid",
+  "maven_version": "invalid",
+  "git_version": "invalid",
+  "jdk11_version": "invalid",
+  "jdk8_version": "invalid",
+  "git_lfs_version": "invalid",
+  "compose_version": "invalid"
 }


### PR DESCRIPTION
the idea of this PR is to make it easier to control the versions
of everything in a single place.