### PR TITLE
Chore: add a daily cloud cleanup task [INFRA-2958]

### DIFF
--- a/CiPodTemplate.yaml
+++ b/CiPodTemplate.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: "v1"
+kind: "Pod"
+spec:
+  restartPolicy: "Never"
+  containers:
+    - name: aws
+      image: jenkinsciinfra/aws:latest
+      command:
+        - cat
+      tty: true
+    - name: packer
+      image: hashicorp/packer:1.7.2
+      command:
+        - cat
+      tty: true
+...

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,10 @@
 
-properties([
-  buildDiscarder(logRotator(numToKeepStr: '10')),
-  pipelineTriggers([cron('@daily')]),
-])
+if (env.BRANCH_NAME == 'main') {
+  properties([
+    buildDiscarder(logRotator(numToKeepStr: '10')),
+    pipelineTriggers([cron('@daily')]),
+  ])
+}
 
 pipeline {
   agent {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,7 +74,7 @@ pipeline {
           }
           stage('Build') {
             when {
-              branch 'master'
+              branch 'main'
             }
             steps {
               sh './run-packer.sh build'
@@ -97,7 +97,7 @@ pipeline {
             AWS_ACCESS_KEY_ID     = credentials('packer-aws-access-key-id')
             AWS_SECRET_ACCESS_KEY = credentials('packer-aws-secret-access-key')
             AWS_REGION            = 'us-east-2'
-            DRYRUN                = "${env.BRANCH_NAME == 'master' ? 'false' : 'true'}"
+            DRYRUN                = "${env.BRANCH_NAME == 'main' ? 'false' : 'true'}"
           }
           steps {
             sh 'bash ./cleanup/aws.sh'

--- a/cleanup/aws.sh
+++ b/cleanup/aws.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+run_aws_ec2_deletion_command() {
+  # Check the DRYRUN environment variable
+  if [ "${DRYRUN:-true}" == "false" ] || [ "${DRYRUN:-true}" == "no" ]
+  then
+    # Execute command "as it"
+    aws ec2 "$@"
+  else
+    # Execute command with the "--dry-run"
+    ec2_subcommand="$1"
+    shift
+    echo "== DRY RUN:"
+    echo "aws ec2 ${ec2_subcommand} --dry-run" "$@"
+    aws ec2 "${ec2_subcommand}" --dry-run "$@" 2>&1 | grep -v 'Request would have succeeded' || true
+  fi
+}
+
+## Check for presence of required CLIs
+for cli in aws jq date xargs
+do
+  command -v "${cli}" >/dev/null || { echo "[ERROR] no '${cli}' command found."; exit 1; }
+done
+
+## When is yesterday exactly?
+yesterday=""
+timeshift_days="1"
+if date -v-${timeshift_days}m > /dev/null 2>&1; then
+    # BSD systems (Mac OS X)
+    yesterday="$(date -v-${timeshift_days}d +%Y-%m-%d)"
+else
+    # GNU systems (Linux)
+    yesterday="$(date --date="-${timeshift_days} days" +%Y-%m-%d)"
+fi
+
+## Check for aws API reachibility (is it configured?)
+aws sts get-caller-identity >/dev/null || \
+  { echo "[ERROR] Unable to request the AWS API: the command 'sts get-caller-identity' failed. Please check your AWS credentials"; exit 1; }
+
+## Remove running instances older than 24 hours
+
+INSTANCE_IDS="$(aws ec2 describe-instances --filters 'Name=tag:Name,Values=*Packer*' \
+  --query 'Reservations[].Instances[?LaunchTime<=`'"${yesterday}"'`][].InstanceId' | jq -r '.[]' | xargs)"
+
+if [ -n "${INSTANCE_IDS}" ]
+then
+  #shellcheck disable=SC2086
+  run_aws_ec2_deletion_command terminate-instances --instance-ids ${INSTANCE_IDS}
+else
+  echo "== No dangling instance found to terminate."
+fi
+
+## Remove security groups older than 24 hours
+for secgroup_id in $(aws ec2 describe-security-groups --filters 'Name=group-name,Values=*packer*' \
+  | jq -r '.SecurityGroups[].GroupId')
+do
+  # Each security group which name matches the pattern '*packer*' is deleted if it is orphaned (not use by any network interface)
+  if [ "0" == "$(aws ec2 describe-network-interfaces --filters "Name=group-id,Values=${secgroup_id}" | jq -r '.NetworkInterfaces | length')" ]
+  then
+    #shellcheck disable=SC2086
+    run_aws_ec2_deletion_command delete-security-group --group-id ${secgroup_id}
+  fi
+done
+
+echo "== AWS Packer Cleanup finished."

--- a/cleanup/aws.sh
+++ b/cleanup/aws.sh
@@ -4,7 +4,7 @@ set -eu -o pipefail
 
 run_aws_ec2_deletion_command() {
   # Check the DRYRUN environment variable
-  if [ "${DRYRUN:-true}" == "false" ] || [ "${DRYRUN:-true}" == "no" ]
+  if [ "${DRYRUN:-true}" = "false" ] || [ "${DRYRUN:-true}" = "no" ]
   then
     # Execute command "as it"
     aws ec2 "$@"
@@ -57,7 +57,7 @@ for secgroup_id in $(aws ec2 describe-security-groups --filters 'Name=group-name
   | jq -r '.SecurityGroups[].GroupId')
 do
   # Each security group which name matches the pattern '*packer*' is deleted if it is orphaned (not use by any network interface)
-  if [ "0" == "$(aws ec2 describe-network-interfaces --filters "Name=group-id,Values=${secgroup_id}" | jq -r '.NetworkInterfaces | length')" ]
+  if [ "0" = "$(aws ec2 describe-network-interfaces --filters "Name=group-id,Values=${secgroup_id}" | jq -r '.NetworkInterfaces | length')" ]
   then
     #shellcheck disable=SC2086
     run_aws_ec2_deletion_command delete-security-group --group-id ${secgroup_id}


### PR DESCRIPTION
This PR introduces the following changes:

- Add a cleanup task, executed at the end of the build. This task is executed in "dry run" all the time, and "for real" on the principal branch. There are 2 types of cleaned resources for now: instances and security groups.
- Fixes Pipeline to support the principal branch name change to `main`
- Switch Pipeline execution to Kubernetes Agent instead of Docker container in EC2 VMs (faster and cheaper)