### PR TITLE
chore: improve resiliency of the azure builds 

### DIFF
--- a/azure/agent.pkr.hcl
+++ b/azure/agent.pkr.hcl
@@ -112,12 +112,15 @@ build {
     winrm_timeout                     = "20m"
     winrm_use_ssl                     = true
     winrm_username                    = "packer"
+    async_resourcegroup_delete        = true # Faster builds, but no deletion error reporting
   }
 
   provisioner "windows-update" {
+    max_retries = 3 # Fight against flaky Windows Updates
   }
 
   provisioner "windows-restart" {
+    max_retries = 3 # Fight against flaky Windows Updates
   }
 
   provisioner "powershell" {


### PR DESCRIPTION
by using retries and async resource deletion to avoid blocking image.

Please note that these changes are only for Windows Server 2019 builds, on Azure.

Signed-off-by: Damien Duportal <damien.duportal@gmail.com>