### PR TITLE
feat: define a semantic version from git tags

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,20 @@ pipeline {
     }
   }
   stages {
+    stage('Prepare') {
+      steps {
+        // Must be on the same agent as the packer steps
+        // TODO: replace me by a custom docker image
+        sh '''
+        apk add --no-cache curl git
+        latest_release_url="$(curl  --write-out "%{redirect_url}" --output /dev/null --silent https://github.com/jenkins-x-plugins/jx-release-version/releases/latest | sed 's#/tag/#/download/#g')"
+        curl --silent --location --show-error "${latest_release_url}/jx-release-version-linux-amd64.tar.gz" \
+          | tar -C /usr/local/bin -x -z -f -
+        jx-release-version --version
+        git fetch --tags # TODO: configure job to fetch tags automatically (migrate to infra.ci?)
+        '''
+      }
+    }
     stage('ValidateAndBuild') {
       matrix {
         axes {

--- a/jenkins-agent.pkr.hcl
+++ b/jenkins-agent.pkr.hcl
@@ -56,9 +56,9 @@ variable "azure_subscription_id" {
   default = ""
   type    = string
 }
-variable "azure_image_version" {
+variable "image_version" {
   type    = string
-  default = "0.0.2"
+  default = "0.0.1" # Default is a valid version to not fail azure validation
 }
 variable "image_type" {
   type        = string
@@ -127,6 +127,7 @@ source "amazon-ebs" "base" {
     imageplatform = var.architecture
     imagetype     = local.image_name
     timestamp     = local.now_unix_timestamp
+    version       = var.image_version
   }
 }
 
@@ -135,6 +136,7 @@ source "azure-arm" "base" {
     imageplatform = var.architecture
     imagetype     = local.image_name
     timestamp     = local.now_unix_timestamp
+    version       = var.image_version
   }
   client_id                         = var.azure_client_id
   client_secret                     = var.azure_client_secret
@@ -148,7 +150,7 @@ source "azure-arm" "base" {
     resource_group      = local.azure_resource_group
     gallery_name        = "prod_packer_images"
     image_name          = local.image_name
-    image_version       = var.azure_image_version
+    image_version       = var.image_version
     replication_regions = ["East US", "East US 2"]
   }
 }

--- a/run-packer.sh
+++ b/run-packer.sh
@@ -15,6 +15,9 @@ set -eu -o pipefail
 
 packer_template_dir="./"
 
+PKR_VAR_image_version="$(jx-release-version -next-version semantic)"
+export PKR_VAR_image_version
+
 ## Always run initialization to ensure plugins are download and workspace is set up
 packer init "${packer_template_dir}"
 


### PR DESCRIPTION
This PR introduces semantic versioning of the images:

* Azure Shared Gallery is now fed the semantic version
* The images (on both Amazon and Azure) all have a tag `version` set to the version's value, to help tracking and cleaning up

The `jx-release-version` command line is used: please note that there is a custom pipeline shell step to gather the requirements. This steps might be replaced later by a custom image.

* `curl` and `git` are installed
* `git` is used to fetch tags (as the job configuration, right now, does not)
* `curl` is used to retrieve `jx-release-version` latest command


The scope of this PR is NOT about automatic tagging/release: this is the work of the next one :)