### PR TITLE
fix: specify the correct architecture for git-lfs package in ubuntu

### DIFF
--- a/scripts/ubuntu-18-provision.sh
+++ b/scripts/ubuntu-18-provision.sh
@@ -72,9 +72,9 @@ else
 fi
 
 ## Install git-lfs (after git)
-git_lfs_deb="/tmp/git-lfs_${GIT_LFS_VERSION}_amd64.deb"
+git_lfs_deb="/tmp/git-lfs_${GIT_LFS_VERSION}_${ARCHITECTURE}.deb"
 curl --fail --silent --location --show-error --output "${git_lfs_deb}" \
-  "https://packagecloud.io/github/git-lfs/packages/debian/stretch/git-lfs_${GIT_LFS_VERSION}_amd64.deb/download"
+  "https://packagecloud.io/github/git-lfs/packages/debian/stretch/git-lfs_${GIT_LFS_VERSION}_${ARCHITECTURE}.deb/download"
 dpkg -i "${git_lfs_deb}"
 rm -f "${git_lfs_deb}"
 


### PR DESCRIPTION
This PR fixes the error `dpkg: error processing archive /tmp/git-lfs_2.13.3_amd64.deb (--install):==> amazon-ebs.ubuntu-18: package architecture (amd64) does not match system (arm64)` caused by #70 