### PR TITLE
Bump git to 2.33.0

### DIFF
--- a/.auto.pkrvars.hcl
+++ b/.auto.pkrvars.hcl
@@ -1,5 +1,5 @@
 maven_version               = "3.8.1"
-git_version                 = "2.32.0"
+git_version                 = "2.33.0"
 jdk11_version               = "11.0.11+9"
 jdk8_version                = "8u292-b10"
 git_lfs_version             = "2.13.3"


### PR DESCRIPTION
This PR bumps git to the version `2.33.0` to fix the failing builds on the principal branch.

It also includes the following changes:

- Never fails some operation in the Ubuntu 20.04 script (to ensure it can be tested in an idempotent way, preparing for future Docker images)
- Provides a better output when a package is not found in the expected version (such as `git 2.32.0` for instance...)
 