### PR TITLE
chore: Add fontconfig to Ubuntu image

### DIFF
--- a/scripts/ubuntu-20-provision.sh
+++ b/scripts/ubuntu-20-provision.sh
@@ -105,6 +105,10 @@ tar xzvf "/tmp/${git_lfs_archive}" -C /tmp/git-lfs
 bash -x /tmp/git-lfs/install.sh # Execute in debug mode in case something goes wrong
 rm -rf /tmp/git-lfs*
 
+## Install JDK needed component
+## Prevent Java null pointer exception due to missing fontconfig
+apt-get install -y --no-install-recommends fontconfig
+
 ## OpenJDKs: Adoptium - https://adoptium.net/installation.html
 # JDK8
 jdk8_short_version="$(echo "${JDK8_VERSION}" | sed 's/-//g')"


### PR DESCRIPTION
## Add fontconfig to Ubuntu 20 image

Java 11 reports a [null pointer exception](https://ci.jenkins.io/job/Plugins/job/git-plugin/job/master/lastCompletedBuild/testReport/hudson.plugins.git/GitSCMTest/linux_8___Build__linux_8____testConfigRoundtrip/) running JenkinsRule tests if the fontconfig package is not available.  Package is included in the Docker agent images also.
