### PR TITLE
fix: Windows builds speed + sysprep

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -10,8 +10,8 @@ if (env.BRANCH_NAME == 'main') {
 pipeline {
   agent none
   options {
-    // Average build time is ~40 min. 2 hours timeout indicates that something is wrong and should fail
-    timeout(time: 2, unit: 'HOURS')
+    // Average build time is ~30 min. 1 hour timeout indicates that something is wrong and should fail
+    timeout(time: 1, unit: 'HOURS')
   }
   stages {
     stage('UpdateCLI') {

--- a/jenkins-agent.pkr.hcl
+++ b/jenkins-agent.pkr.hcl
@@ -90,7 +90,7 @@ locals {
     "azure-arm"  = "packer"
     "amazon-ebs" = "Administrator"
   }
-  azure_vm_size = "Standard_DS4_v2" # Huge size requires - avoid https://docs.microsoft.com/en-us/azure/virtual-machines/linux/image-builder-troubleshoot#sysprep-timing and avoid full disk (DS2v2 only have 14 Gb SSD for system)
+  azure_vm_size        = "Standard_D4s_v3" # Huge size requires - avoid https://docs.microsoft.com/en-us/azure/virtual-machines/linux/image-builder-troubleshoot#sysprep-timing and avoid full disk (DS2v2 only have 14 Gb SSD for system)
   azure_resource_group = "${var.build_type}-packer-images"
   azure_galleries = {
     "prod_packer_images"    = ["East US", "East US 2"]

--- a/jenkins-agent.pkr.hcl
+++ b/jenkins-agent.pkr.hcl
@@ -244,17 +244,16 @@ build {
     async_resourcegroup_delete = true # Faster builds, but no deletion error reporting
   }
 
-  provisioner "windows-update" {
-    max_retries = 3 # Fight against flaky Windows Updates
-  }
-
-  provisioner "windows-restart" {
-    max_retries = 3 # Fight against flaky Windows Updates
-  }
+  ## Why repeating? https://github.com/rgl/packer-plugin-windows-update/issues/90#issuecomment-842569865
+  # Note that restarts are only done when required by windows updates
+  provisioner "windows-update" { pause_before = "1m" }
+  provisioner "windows-update" { pause_before = "1m" }
+  provisioner "windows-update" { pause_before = "1m" }
 
   provisioner "file" {
-    source      = "./scripts/addSSHPubKey.ps1"
-    destination = "C:/"
+    pause_before = "1m"
+    source       = "./scripts/addSSHPubKey.ps1"
+    destination  = "C:/"
   }
 
   provisioner "powershell" {

--- a/scripts/windows-2019-provision.ps1
+++ b/scripts/windows-2019-provision.ps1
@@ -190,18 +190,8 @@ switch($env:CLOUD_TYPE) {
         C:\ProgramData\Amazon\EC2-Windows\Launch\Scripts\SendWindowsIsReady.ps1 -Schedule
     }
     'azure-arm' {
-        # Azure needs the image sysprep'd manually, AWS is done using AWS scripts from the json
-        & $env:SystemRoot\System32\Sysprep\Sysprep.exe /oobe /generalize /quiet /quit
-        while($true) {
-            $imageState = Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Setup\State' | Select-Object ImageState
-            if($imageState.ImageState -ne 'IMAGE_STATE_GENERALIZE_RESEAL_TO_OOBE') {
-                Write-Output $imageState.ImageState
-                Start-Sleep -s 5
-            } else {
-                break
-            }
-        }
-        Break
+        # Azure needs the image sysprep'd manually
+        & $env:SystemRoot\System32\Sysprep\Sysprep.exe /oobe /generalize /quiet /shutdown
     }
 }
 

--- a/scripts/windows-2019-provision.ps1
+++ b/scripts/windows-2019-provision.ps1
@@ -54,6 +54,7 @@ Function Retry-Command {
 Function DownloadFile($url, $targetFile) {
     Write-Host "Downloading $url"
     Retry-Command -ScriptBlock {
+        $ProgressPreference = 'SilentlyContinue' # Disable Progress bar for faster downloads
         Invoke-WebRequest $url -OutFile $targetFile
     }
 }


### PR DESCRIPTION
This PR introduces the following fixes to the windows builds and provisioning:

- Increase instance size to have enough I/O and network
- Add multiples instances of `windows-updates` as per https://github.com/rgl/packer-plugin-windows-update/issues/90#issuecomment-842276886 (tip from the author of the packer plugin to handle all windows updates edge cases)
  - implies using the provisioner's attribute `pause_before`
- Improve download performances on powershell script by disabling the progress bar (the gain is impressive: from 6m to 40s for downloading JDK11 for instance)
- Stop waiting for sys prep to reach a certain state: sometimes it's never reached until the VM is restarted, and there are no impacts in an environment such as this one (issue with the build stuck on loop with the message `IMAGE_STATE_COMPLETE` printed out)
- Putting back the timeout to 1 hour


The new build time shrank from ~39-40min to 29-30 min which is a win \o/