### PR TITLE
chore [updatecli] fail automatic update of maven if there are no binary available

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -14,14 +14,35 @@ pipeline {
     timeout(time: 1, unit: 'HOURS')
   }
   stages {
-    stage('UpdateCLI') {
-      steps {
-        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-          script {
-            withCredentials([string(credentialsId: 'updatecli-github-token', variable: 'UPDATECLI_GITHUB_TOKEN')]) {
-              updatecli(action: 'diff')
-              if (env.BRANCH_NAME == 'main') {
-                updatecli(action: 'apply', cronTriggerExpression: '@daily')
+    stage('Side Tasks') {
+      parallel {
+        stage('GC on AWS us-east-2') {
+          agent {
+            kubernetes {
+              defaultContainer 'aws'
+              yamlFile 'CiPodTemplate.yaml'
+            }
+          }
+          environment {
+            AWS_ACCESS_KEY_ID     = credentials('packer-aws-access-key-id')
+            AWS_SECRET_ACCESS_KEY = credentials('packer-aws-secret-access-key')
+            AWS_REGION            = 'us-east-2'
+            DRYRUN                = "${env.BRANCH_NAME == 'main' ? 'false' : 'true'}"
+          }
+          steps {
+            sh './cleanup/aws.sh'
+          }
+        }
+        stage('Updatecli') {
+          steps {
+            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+              script {
+                withCredentials([string(credentialsId: 'updatecli-github-token', variable: 'UPDATECLI_GITHUB_TOKEN')]) {
+                  updatecli(action: 'diff')
+                  if (env.BRANCH_NAME == 'main') {
+                    updatecli(action: 'apply', cronTriggerExpression: '@daily')
+                  }
+                }
               }
             }
           }
@@ -138,27 +159,6 @@ pipeline {
             steps {
               sh './run-packer.sh build'
             }
-          }
-        }
-      }
-    }
-    stage('Garbage Collection of Cloud Resources') {
-      parallel {
-        stage('Cleanup AWS us-east-2') {
-          agent {
-            kubernetes {
-              defaultContainer 'aws'
-              yamlFile 'CiPodTemplate.yaml'
-            }
-          }
-          environment {
-            AWS_ACCESS_KEY_ID     = credentials('packer-aws-access-key-id')
-            AWS_SECRET_ACCESS_KEY = credentials('packer-aws-secret-access-key')
-            AWS_REGION            = 'us-east-2'
-            DRYRUN                = "${env.BRANCH_NAME == 'main' ? 'false' : 'true'}"
-          }
-          steps {
-            sh './cleanup/aws.sh'
           }
         }
       }

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -30,7 +30,9 @@ pipeline {
             DRYRUN                = "${env.BRANCH_NAME == 'main' ? 'false' : 'true'}"
           }
           steps {
-            sh './cleanup/aws.sh'
+            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+              sh './cleanup/aws.sh'
+            }
           }
         }
         stage('Updatecli') {

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -16,11 +16,13 @@ pipeline {
   stages {
     stage('UpdateCLI') {
       steps {
-        script {
-          withCredentials([string(credentialsId: 'updatecli-github-token', variable: 'UPDATECLI_GITHUB_TOKEN')]) {
-            updatecli(action: 'diff')
-            if (env.BRANCH_NAME == 'main') {
-              updatecli(action: 'apply', cronTriggerExpression: '@daily')
+        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+          script {
+            withCredentials([string(credentialsId: 'updatecli-github-token', variable: 'UPDATECLI_GITHUB_TOKEN')]) {
+              updatecli(action: 'diff')
+              if (env.BRANCH_NAME == 'main') {
+                updatecli(action: 'apply', cronTriggerExpression: '@daily')
+              }
             }
           }
         }

--- a/updatecli/scripts/check-maven.sh
+++ b/updatecli/scripts/check-maven.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -eux
+
+MAVEN_VERSION="${1}"
+
+command -v curl >/dev/null 2>&1 || { echo "ERROR: curl command not found. Exiting."; exit 1; }
+
+curl --connect-timeout 5 --location --head --fail --silent --show-error \
+  "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz"

--- a/updatecli/updatecli.d/maven.yml
+++ b/updatecli/updatecli.d/maven.yml
@@ -2,7 +2,6 @@
 title: "Bump Maven version"
 sources:
   mavenVersion:
-    # Version is retrieved from the GitHub source mirror: if there is a release, then you're sure that the artifacts are available
     kind: githubRelease
     name: Get the latest Maven version
     spec:
@@ -34,6 +33,14 @@ sources:
       - replacer:
           from: '{{ source "packerVarMavenCurrentLine" }}'
           to: 'maven_version = "{{ source "mavenVersion" }}"'
+
+conditions:
+  checkIfMavenReleaseIsAvailable:
+    kind: shell
+    sourceID: mavenVersion
+    spec:
+      command: bash ./updatecli/scripts/check-maven.sh
+
 targets:
   updateMavenVersion:
     name: Update the Maven version in the Packer default values


### PR DESCRIPTION
This Pull Request should close #98 , that was opened by the bot, from the updatecli manifest for Maven: the Maven tag 3.8.3 has been published but the binary is not generally available.

A condition had been added to the updatecli's maven manifest, so no PR will be opened if the binary is not available.