### PR TITLE
chore [updatecli] pin git-lfs to major version 2.x.y

### DIFF
--- a/updatecli/updatecli.d/git-lfs.yml
+++ b/updatecli/updatecli.d/git-lfs.yml
@@ -11,6 +11,7 @@ sources:
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
       versionFilter:
+        pattern: ~2
         kind: semver
   # Retrieve the line defining Git-LFS version from Packer Auto Vars. file (it's a trick to handle partial file update)
   packerVarGitLfsCurrentLine:


### PR DESCRIPTION
This PR closes #99 by only checking for 2.x versions of git-lfs.