### PR TITLE
Feat: Define a common paths for JDKs, only based upon major versions

### DIFF
--- a/scripts/ubuntu-20-provision.sh
+++ b/scripts/ubuntu-20-provision.sh
@@ -10,7 +10,7 @@ echo "ARCHITECTURE=${ARCHITECTURE}"
 echo "COMPOSE_VERSION=${COMPOSE_VERSION}"
 echo "MAVEN_VERSION=${MAVEN_VERSION}"
 export DEBIAN_FRONTEND=noninteractive
-ubuntu_codename="$(cat /etc/os-release | grep UBUNTU_CODENAME | cut -d = -f 2)"
+ubuntu_codename="$(grep UBUNTU_CODENAME /etc/os-release | cut -d = -f 2)"
 
 ## Check for presence of requirements or fail fast
 for cli in add-apt-repository apt-get apt-cache awk curl grep groupadd head tar uname useradd
@@ -111,7 +111,7 @@ apt-get install -y --no-install-recommends fontconfig
 
 ## OpenJDKs: Adoptium - https://adoptium.net/installation.html
 # JDK8
-jdk8_short_version="$(echo "${JDK8_VERSION}" | sed 's/-//g')"
+jdk8_short_version="${JDK8_VERSION//-/}"
 cpu_arch_short="$(uname -m)"
 if test "${cpu_arch_short}" == "x86_64"
 then
@@ -122,21 +122,21 @@ curl -sSL -o /tmp/jdk8.tgz \
   "https://github.com/adoptium/temurin8-binaries/releases/download/jdk${JDK8_VERSION}/OpenJDK8U-jdk_${cpu_arch_short}_linux_hotspot_${jdk8_short_version}.tar.gz"
 tar xzf /tmp/jdk8.tgz -C /opt
 # Priority (last argument) is set to the JDK major version: higher version will be the default used
-update-alternatives --install /usr/bin/java java /opt/jdk${JDK8_VERSION}/bin/java 8
+update-alternatives --install /usr/bin/java java "/opt/jdk${JDK8_VERSION}/bin/java" 8
 
 # JDK11
-jdk11_short_version="$(echo "${JDK11_VERSION}" | sed 's/+/_/g')"
+jdk11_short_version="${JDK11_VERSION//+/_}"
 curl -sSL -o /tmp/jdk11.tgz \
   "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-${JDK11_VERSION}/OpenJDK11U-jdk_${cpu_arch_short}_linux_hotspot_${jdk11_short_version}.tar.gz"
 tar xzf /tmp/jdk11.tgz -C /opt
-update-alternatives --install /usr/bin/java java /opt/jdk-${JDK11_VERSION}/bin/java 11
+update-alternatives --install /usr/bin/java java "/opt/jdk-${JDK11_VERSION}/bin/java" 11
 
 # JDK17
-jdk17_short_version="$(echo "${JDK17_VERSION}" | sed 's/+/_/g')"
+jdk17_short_version="${JDK17_VERSION//+/_}"
 curl -sSL -o /tmp/jdk17.tgz \
   "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-${JDK17_VERSION}/OpenJDK17-jdk_${cpu_arch_short}_linux_hotspot_${jdk17_short_version}.tar.gz"
 tar xzf /tmp/jdk17.tgz -C /opt
-update-alternatives --install /usr/bin/java java /opt/jdk-${JDK17_VERSION}/bin/java 17
+update-alternatives --install /usr/bin/java java "/opt/jdk-${JDK17_VERSION}/bin/java" 17
 
 ## Ensure that docker-compose is installed (version from environment)
 curl --fail --silent --location --show-error --output /usr/local/bin/docker-compose \

--- a/scripts/ubuntu-20-provision.sh
+++ b/scripts/ubuntu-20-provision.sh
@@ -110,6 +110,8 @@ rm -rf /tmp/git-lfs*
 apt-get install -y --no-install-recommends fontconfig
 
 ## OpenJDKs: Adoptium - https://adoptium.net/installation.html
+mkdir -p /opt/jdk-8 /opt/jdk-11 /opt/jdk-17
+
 # JDK8
 jdk8_short_version="${JDK8_VERSION//-/}"
 cpu_arch_short="$(uname -m)"
@@ -120,23 +122,25 @@ then
 fi
 curl -sSL -o /tmp/jdk8.tgz \
   "https://github.com/adoptium/temurin8-binaries/releases/download/jdk${JDK8_VERSION}/OpenJDK8U-jdk_${cpu_arch_short}_linux_hotspot_${jdk8_short_version}.tar.gz"
-tar xzf /tmp/jdk8.tgz -C /opt
-# Priority (last argument) is set to the JDK major version: higher version will be the default used
-update-alternatives --install /usr/bin/java java "/opt/jdk${JDK8_VERSION}/bin/java" 8
+tar xzf /tmp/jdk8.tgz --strip-components=1 -C /opt/jdk-8
 
 # JDK11
 jdk11_short_version="${JDK11_VERSION//+/_}"
 curl -sSL -o /tmp/jdk11.tgz \
   "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-${JDK11_VERSION}/OpenJDK11U-jdk_${cpu_arch_short}_linux_hotspot_${jdk11_short_version}.tar.gz"
-tar xzf /tmp/jdk11.tgz -C /opt
-update-alternatives --install /usr/bin/java java "/opt/jdk-${JDK11_VERSION}/bin/java" 11
+tar xzf /tmp/jdk11.tgz --strip-components=1 -C /opt/jdk-11
 
 # JDK17
 jdk17_short_version="${JDK17_VERSION//+/_}"
 curl -sSL -o /tmp/jdk17.tgz \
   "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-${JDK17_VERSION}/OpenJDK17-jdk_${cpu_arch_short}_linux_hotspot_${jdk17_short_version}.tar.gz"
-tar xzf /tmp/jdk17.tgz -C /opt
-update-alternatives --install /usr/bin/java java "/opt/jdk-${JDK17_VERSION}/bin/java" 17
+tar xzf /tmp/jdk17.tgz --strip-components=1 -C /opt/jdk-17
+
+# Define JDK installations
+# Priority (last argument) is set to the JDK major version: higher version will be the default used
+update-alternatives --install /usr/bin/java java /opt/jdk-8/bin/java 8
+update-alternatives --install /usr/bin/java java /opt/jdk-11/bin/java 11
+update-alternatives --install /usr/bin/java java /opt/jdk-17/bin/java 17
 
 ## Ensure that docker-compose is installed (version from environment)
 curl --fail --silent --location --show-error --output /usr/local/bin/docker-compose \

--- a/scripts/windows-2019-provision.ps1
+++ b/scripts/windows-2019-provision.ps1
@@ -76,22 +76,31 @@ New-Item -ItemType Directory -Path $baseDir -Force | Out-Null
 $downloads = [ordered]@{
     'jdk11' = @{
         'url' = 'https://github.com/adoptium/temurin11-binaries/releases/download/jdk-{0}/OpenJDK11U-jdk_x64_windows_hotspot_{1}.zip' -f [System.Web.HTTPUtility]::UrlEncode($env:JDK11_VERSION),$env:JDK11_VERSION.Replace('+', '_');
-        'local' = "$baseDir\adoptOpenJDK11.zip";
+        'local' = "$baseDir\temurin11.zip";
         'expandTo' = $baseDir;
         'env' = @{
-            'JAVA_HOME' = '{0}\jdk-{1}' -f $baseDir,$env:JDK11_VERSION;
+            'JAVA_HOME' = '{0}\jdk-11' -f $baseDir;
         };
-        'path' = '{0}\jdk-{1}\bin' -f $baseDir,$env:JDK11_VERSION;
+        'path' = '{0}\jdk-11\bin' -f $baseDir;
+        'postexpand' = {
+            & Move-Item -Path "$baseDir\jdk-11*" -Destination "$baseDir\jdk-11"
+        };
     };
     'jdk17' = @{
         'url' = 'https://github.com/adoptium/temurin17-binaries/releases/download/jdk-{0}/OpenJDK17-jdk_x64_windows_hotspot_{1}.zip' -f [System.Web.HTTPUtility]::UrlEncode($env:JDK17_VERSION),$env:JDK17_VERSION.Replace('+', '_');
         'local' = "$baseDir\temurin17.zip";
         'expandTo' = $baseDir;
+        'postexpand' = {
+            & Move-Item -Path "$baseDir\jdk-17*" -Destination "$baseDir\jdk-17"
+        };
     };
     'jdk8' = @{
         'url' = 'https://github.com/adoptium/temurin8-binaries/releases/download/jdk{0}/OpenJDK8U-jdk_x64_windows_hotspot_{1}.zip' -f $env:JDK8_VERSION,$env:JDK8_VERSION.Replace('-', '')
-        'local' = "$baseDir\adoptOpenJDK8.zip";
+        'local' = "$baseDir\temurin8.zip";
         'expandTo' = $baseDir;
+        'postexpand' = {
+            & Move-Item -Path "$baseDir\jdk8*" -Destination "$baseDir\jdk-8"
+        };
     };
     'maven' = @{
         'url' = 'https://apache.osuosl.org/maven/maven-3/{0}/binaries/apache-maven-{0}-bin.zip' -f $env:MAVEN_VERSION;


### PR DESCRIPTION
This PR defines static installation paths for the JDK installation, which only depends on the java major version, to avoid the maintenance burden.

Ref. https://github.com/jenkins-infra/pipeline-library/issues/228#issuecomment-930219117.

The new paths are:

- Ubuntu Linux 20.04: 

```shell
/opt/jdk-8
/opt/jdk-11
/opt/jdk-17
```

- Windows 2019:

```powershell
C:\Tools\jdk-8
C:\Tools\jdk-11
C:\Tools\jdk-17
```
