### PR TITLE
fix [azure windows-2019] use smaller base OS image to allow OS disk <100Gb

### DIFF
--- a/jenkins-agent.pkr.hcl
+++ b/jenkins-agent.pkr.hcl
@@ -239,7 +239,7 @@ build {
     communicator               = "winrm"
     image_offer                = "WindowsServer"
     image_publisher            = "MicrosoftWindowsServer"
-    image_sku                  = "2019-Datacenter-Core-with-Containers-g2"
+    image_sku                  = "2019-datacenter-core-with-containers-smalldisk-g2"
     vm_size                    = local.azure_vm_size
     os_type                    = "Windows"
     os_disk_size_gb            = local.os_disk_size_gb


### PR DESCRIPTION
This PR uses the "smalldisk" version of Windows server Core 2019 with Container generation 2 (yes that is a loooong name).

This base OS features a system drive at 30 Gb instead of 127 Gb, leaving us a lot of room for builds (~75 Gb), but staying below the limit of 100 Gb disks.