### PR TITLE
Allow git LFS upgrade

### DIFF
--- a/updatecli/updatecli.d/git-lfs.yml
+++ b/updatecli/updatecli.d/git-lfs.yml
@@ -11,7 +11,6 @@ sources:
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
       versionFilter:
-        pattern: ~2
         kind: semver
   # Retrieve the line defining Git-LFS version from Packer Auto Vars. file (it's a trick to handle partial file update)
   packerVarGitLfsCurrentLine:


### PR DESCRIPTION
## Allow git LFS upgrade

Testing of git LFS 3.0.1 has been successful in all the cases that I have tested.  The blocking issue in git LFS 3.0.0 is resolved.

This reverts commit ff6e722173039e09a8f41243fb5d22656b34322a.
