### PR TITLE
chore [updatecli] stop checking for maven

### DIFF
--- a/updatecli/updatecli.d/maven.yml
+++ b/updatecli/updatecli.d/maven.yml
@@ -34,12 +34,13 @@ sources:
           from: '{{ source "packerVarMavenCurrentLine" }}'
           to: 'maven_version = "{{ source "mavenVersion" }}"'
 
-conditions:
-  checkIfMavenReleaseIsAvailable:
-    kind: shell
-    sourceID: mavenVersion
-    spec:
-      command: bash ./updatecli/scripts/check-maven.sh
+### curl is not available in the Docker image we are using
+# conditions:
+#   checkIfMavenReleaseIsAvailable:
+#     kind: shell
+#     sourceID: mavenVersion
+#     spec:
+#       command: bash ./updatecli/scripts/check-maven.sh
 
 targets:
   updateMavenVersion:


### PR DESCRIPTION
It's a temp. workaround that disable the "condition" on the updatecli task for maven.

Error is the following:
```
The shell 🐚 command "bash ./updatecli/scripts/check-maven.sh 3.8.3" failed with an exit code of 1 and the following messages: 
stderr=
ERROR: curl command not found. Exiting.
stdout=
+ MAVEN_VERSION=3.8.3
+ command -v curl
+ echo 'ERROR: curl command not found. Exiting.'
+ exit 1
```

=> the default updatecli image we are using in the shared library (https://github.com/jenkins-infra/pipeline-library/blob/master/vars/updatecli.groovy#L7) is currently not having curl or wget, and unable to install any tool.