### PR TITLE
chore(Jenkinsfile) the jx-release-version is not needed anymore

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -143,12 +143,6 @@ pipeline {
               echo 'scm_ref = "'"$(git rev-parse --short --verify HEAD)"'"' >> "${PACKER_VARS_FILE}"
               packer fmt -recursive .
               ./run-packer.sh report
-              ## TODO: create a docker-packer image with these tools within, instead of the bare hashicorp/packer image
-              apk add --no-cache curl git
-              latest_release_url="$(curl  --write-out "%{redirect_url}" --output /dev/null --silent https://github.com/jenkins-x-plugins/jx-release-version/releases/latest | sed 's#/tag/#/download/#g')"
-              curl --silent --location --show-error "${latest_release_url}/jx-release-version-linux-amd64.tar.gz" | tar -C /usr/local/bin -x -z -f -
-              jx-release-version --version
-              ######
               '''
             }
           }


### PR DESCRIPTION
Signed-off-by: Damien Duportal <damien.duportal@gmail.com>