### PR TITLE
Install Python 3

### DIFF
--- a/scripts/ubuntu-20-provision.sh
+++ b/scripts/ubuntu-20-provision.sh
@@ -97,6 +97,13 @@ else
   apt-get install -y --no-install-recommends git
 fi
 
+# Install Python 3
+apt-get install -y --no-install-recommends \
+  python3 \
+  python3-docker \
+  python3-pip \
+  python3-venv
+
 ## Install git-lfs (after git)
 git_lfs_archive="git-lfs-linux-${ARCHITECTURE}-v${GIT_LFS_VERSION}.tar.gz"
 git_lfs_release_url="https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/${git_lfs_archive}"

--- a/scripts/ubuntu-20-provision.sh
+++ b/scripts/ubuntu-20-provision.sh
@@ -102,7 +102,8 @@ apt-get install -y --no-install-recommends \
   python3 \
   python3-docker \
   python3-pip \
-  python3-venv
+  python3-venv \
+  python3-wheel
 
 ## Install git-lfs (after git)
 git_lfs_archive="git-lfs-linux-${ARCHITECTURE}-v${GIT_LFS_VERSION}.tar.gz"


### PR DESCRIPTION
### Context

The `jenkinsci/packaging` repository accepts pull requests, but the `Jenkinsfile` does not run the tests in CI. As a result the packages are at high risk of regression (jenkinsci/packaging#235). To solve this problem, I have proposed jenkinsci/packaging#240 to add test coverage for the packages in the `Jenkinsfile`. That PR, on @dduportal's suggestion, runs this workload on the VM agents available on `ci.jenkins.io` by using the `docker` label.

### Problem

The VM agents available on `ci.jenkins.io` lack the packages needed to run Python jobs, including Ansible/Molecule tests. I was able to work around this in jenkinsci/packaging#240 by adding the following shell script to my Jenkins job:

```shell
sudo apt-get update && sudo apt-get install -y python3-docker python3-pip python3-venv
```

However, this is slow and fragile. Better would be to have these packages backed into the base image.

### Solution

Install these packages as part of the base image.

### Testing Done

Ran the job from jenkinsci/packaging#240 with the abovementioned workaround and verified that Ansible/Molecule tests passed.