### PR TITLE
Use JDK 17.0.2, not 17.0

### DIFF
--- a/.auto.pkrvars.hcl
+++ b/.auto.pkrvars.hcl
@@ -1,7 +1,7 @@
 maven_version               = "3.8.4"
 git_version                 = "2.35.1"
 jdk11_version               = "11.0.14+9"
-jdk17_version               = "17+35"
+jdk17_version               = "17.0.2+8"
 jdk8_version                = "8u322-b06"
 default_jdk                 = "11"
 git_lfs_version             = "3.0.2"

--- a/scripts/ubuntu-20-provision.sh
+++ b/scripts/ubuntu-20-provision.sh
@@ -69,7 +69,7 @@ function install_docker() {
     software-properties-common
 
   #using the local version of the docker public key avoid curl errors
-  gpg --no-tty --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg /tmp/docker.gpg
+  gpg --batch --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg /tmp/docker.gpg
   echo \
     "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
     $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null

--- a/updatecli/scripts/check-jdk.sh
+++ b/updatecli/scripts/check-jdk.sh
@@ -13,17 +13,17 @@ function get_jdk_download_url() {
   jdk_version="${1}"
   platform="${2}"
   case "${jdk_version}" in
-    8u*)
+    8*)
       ## JDK8 does not have the carret ('-') in their archive names
       echo "https://github.com/adoptium/temurin8-binaries/releases/download/jdk${jdk_version}/OpenJDK8U-jdk_${platform}_hotspot_${jdk_version//-}";
       return 0;;
-    11.*)
+    11*)
       ## JDK11 URLs have an underscore ('_') instead of a plus ('+') in their archive names
       echo "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-${jdk_version}/OpenJDK11U-jdk_${platform}_hotspot_${jdk_version//+/_}";
       return 0;;
-    17+*)
+    17*)
       ## JDK17 URLs have an underscore ('_') instead of a plus ('+') in their archive names
-      echo "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-${jdk_version}/OpenJDK17-jdk_${platform}_hotspot_${jdk_version//+/_}";
+      echo "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-${jdk_version}/OpenJDK17U-jdk_${platform}_hotspot_${jdk_version//+/_}";
       return 0;;
     *)
       echo "ERROR: unsupported JDK version (${jdk_version}).";

--- a/updatecli/updatecli.d/jdk17.yml
+++ b/updatecli/updatecli.d/jdk17.yml
@@ -24,8 +24,8 @@ sources:
       username: "{{ .github.username }}"
       versionFilter:
         kind: regex
-        # jdk-17+35(https://github.com/adoptium/temurin17-binaries/releases/tag/jdk-17%2B35) is OK
-        pattern: "^jdk-17\\+(\\d*)$"
+        # jdk-17.0.2+8(https://github.com/adoptium/temurin17-binaries/releases/tag/jdk-17.0.2%2B8) is OK
+        pattern: "^jdk-17.(\\d*).(\\d*).(\\d*)+(\\d*)$"
     transformers:
       - trimPrefix: "jdk-"
 


### PR DESCRIPTION
## Use JDK 17.0.2, not JDK 17.0

Refines the updatecli definition to use the same pattern as is used for JDK 11.

Makes progress on jenkins-infra/helpdesk#2758
