### PR TITLE
chore: GC for azure resources group from packer process

### DIFF
--- a/CiPodTemplate.yaml
+++ b/CiPodTemplate.yaml
@@ -4,4 +4,4 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: jnlp
-      image: jenkinsciinfra/hashicorp-tools:0.3.12
+      image: jenkinsciinfra/hashicorp-tools:0.3.13

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -37,7 +37,7 @@ pipeline {
         stage('GC on Azure') {
           environment {
             PACKER_AZURE = credentials('packer-azure-serviceprincipal')
-            DRYRUN = "${env.BRANCH_NAME == 'main' ? 'false' : 'true'}"
+            DRYRUN = "${env.BRANCH_IS_PRIMARY ? 'false' : 'true'}"
           }
           
           agent {

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -36,7 +36,6 @@ pipeline {
         }
         stage('GC on Azure') {
           environment {
-            
             PACKER_AZURE = credentials('packer-azure-serviceprincipal')
             DRYRUN = "${env.BRANCH_NAME == 'main' ? 'false' : 'true'}"
           }
@@ -49,8 +48,8 @@ pipeline {
           
           steps {
             catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-              sh 'az login --service-principal -u "$AZURE_CLIENT_ID" -p "$AZURE_CLIENT_SECRET" -t "$AZURE_TENANT_ID"'
-              sh 'az account set -s "$AZURE_SUBSCRIPTION_ID"'
+              sh 'az login --service-principal -u "$PACKER_AZURE_CLIENT_ID" -p "$PACKER_AZURE_CLIENT_SECRET" -t "$PACKER_AZURE_TENANT_ID"'
+              sh 'az account set -s "$PACKER_AZURE_SUBSCRIPTION_ID"'
               sh './cleanup/azure.sh'
             }
           }

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -36,9 +36,8 @@ pipeline {
         }
         stage('GC on Azure') {
           environment {
-            PKR_VAR_azure_subscription_id = credentials('packer-azure-subscription-id')
-            PKR_VAR_azure_client_id       = credentials('packer-azure-client-id')
-            PKR_VAR_azure_client_secret   = credentials('packer-azure-client-secret')
+            
+            PACKER_AZURE = credentials('packer-azure-serviceprincipal')
             DRYRUN = "${env.BRANCH_NAME == 'main' ? 'false' : 'true'}"
           }
           
@@ -50,7 +49,7 @@ pipeline {
           
           steps {
             catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-              sh 'az login --service-principal -u "$PKR_VAR_azure_client_id" -p "$PKR_VAR_azure_client_secret"'
+              sh 'az login --service-principal -u "$AZURE_CLIENT_ID" -p "$AZURE_CLIENT_SECRET" -t "$AZURE_TENANT_ID"'
               sh 'az account set -s "$AZURE_SUBSCRIPTION_ID"'
               sh './cleanup/azure.sh'
             }

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -34,6 +34,32 @@ pipeline {
             }
           }
         }
+        stage('GC on Azure') {
+          environment {
+            PKR_VAR_azure_subscription_id = credentials('packer-azure-subscription-id')
+            PKR_VAR_azure_client_id       = credentials('packer-azure-client-id')
+            PKR_VAR_azure_client_secret   = credentials('packer-azure-client-secret')
+            DRYRUN = "${env.BRANCH_NAME == 'main' ? 'false' : 'true'}"
+          }
+          
+          agent {
+            kubernetes {
+              yamlFile 'CiPodTemplate.yaml'
+            }
+          }
+          
+          steps {
+            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+              sh '''
+                az login --service-principal \
+                    -u "$PKR_VAR_azure_client_id" \
+                    -p "$PKR_VAR_azure_client_secret" \
+                    -t "$PKR_VAR_azure_subscription_id"
+              '''
+              sh './cleanup/azure.sh'
+            }
+          }
+        }
         stage('Updatecli') {
           steps {
             catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -50,12 +50,8 @@ pipeline {
           
           steps {
             catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-              sh '''
-                az login --service-principal \
-                    -u "$PKR_VAR_azure_client_id" \
-                    -p "$PKR_VAR_azure_client_secret" \
-                    -t "$PKR_VAR_azure_subscription_id"
-              '''
+              sh 'az login --service-principal -u "$PKR_VAR_azure_client_id" -p "$PKR_VAR_azure_client_secret"'
+              sh 'az account set -s "$AZURE_SUBSCRIPTION_ID"'
               sh './cleanup/azure.sh'
             }
           }

--- a/cleanup/azure.sh
+++ b/cleanup/azure.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+run_az_deletion_command() {
+  # Check the DRYRUN environment variable
+  if [ "${DRYRUN:-true}" = "false" ] || [ "${DRYRUN:-true}" = "no" ]
+  then
+    # Execute command "as it"
+    echo "command that would be executed : "
+    echo "az group" "$@"
+    az group "$@"
+  else
+    # Execute command with the "--dry-run"
+    subcommand="$1"
+    shift
+    echo "== DRY RUN (show instead of ${subcommand}):"
+    echo "az group show $@"
+    az group show "$@" 2>&1 | grep -v 'Request would have succeeded' || true
+  fi
+}
+
+## Check for presence of required CLIs
+for cli in az jq date xargs
+do
+  command -v "${cli}" >/dev/null || { echo "[ERROR] no '${cli}' command found."; exit 1; }
+done
+
+## When is yesterday exactly in YYYYMMDDHMMSS
+yesterday=""
+timeshift_days="1"
+if date -v-${timeshift_days}m > /dev/null 2>&1; then
+    # BSD systems (Mac OS X)
+    yesterday="$(date -v-${timeshift_days}d +%Y%m%d%H%M%S)"
+else
+    # GNU systems (Linux)
+    yesterday="$(date --date="-${timeshift_days} days" +%Y%m%d%H%M%S)"
+fi
+
+## Check for aws API reachability (is it configured?)
+az account show >/dev/null || \
+  { echo "[ERROR] Unable to request the Azure API: the command 'az account show' failed. Please check your Azure credentials"; exit 1; }
+
+## Remove running instances older than 24 hours
+#az group list --query '[?tags.timestamp<'\''20220222222222'\''] | [?starts_with(name, '\''pkr-Resource-'\'')].name'
+INSTANCE_IDS="$(az group list --query '[?tags.timestamp<='\''`'"${yesterday}"'`'\''] | [?starts_with(name, '\''pkr-Resource-'\'')].name'| jq -r '.[]' | xargs)" 
+
+if [ -n "${INSTANCE_IDS}" ]
+then
+  #shellcheck disable=SC2086
+  #has to run on each resource group
+  cpt="0"
+  for rg in ${INSTANCE_IDS}
+  do
+    run_az_deletion_command delete --name $rg
+    ((cpt=cpt+1))
+  done
+  echo "== $cpt resources group have been deleted"
+else
+  echo "== No dangling instance found to terminate."
+fi
+
+echo "== Azure Packer Cleanup finished."


### PR DESCRIPTION
Find every resources group that start with "pkr-Resource-" and is more than 1 day old from the tag timestamp and delete them as per the model for AWS : https://github.com/jenkins-infra/helpdesk/issues/2812

2 differences:  

-    no --dry-run in azure so I switch to the show sub-command to dry run
-    no batch delete command so I loop within the result list to delete one by one.   

PS : didn't add a location check as per : https://github.com/jenkins-infra/packer-images/blob/7a990b12227136625752012755dda690dc1475c2/jenkins-agent.pkr.hcl#L179 this seems to always be "eastus"