### PR TITLE
chore(Jenkinsfile) Use githubApp credentials for packer instead of a Github bot user token

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -135,7 +135,7 @@ pipeline {
           PACKER_PLUGIN_PATH            = "${PACKER_HOME_DIR}/plugins"
           PACKER_VARS_FILE              = ".auto.pkrvars.hcl"
           // Reuse the updatecli Github token to ensure that packer init does not hit the rate limit
-          PACKER_GITHUB_API_TOKEN       = credentials('updatecli-github-token')
+          PACKER_GITHUB_API_TOKEN       = credentials('github-app-infra')
         }
         stages {
           stage('Prepare on primary branch') {

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -135,7 +135,8 @@ pipeline {
           PACKER_PLUGIN_PATH            = "${PACKER_HOME_DIR}/plugins"
           PACKER_VARS_FILE              = ".auto.pkrvars.hcl"
           // Reuse the updatecli Github token to ensure that packer init does not hit the rate limit
-          PACKER_GITHUB_API_TOKEN       = credentials('github-app-infra')
+          GITHUB_IAT_TOKEN              = credentials('github-app-infra')
+          PACKER_GITHUB_API_TOKEN       = "${GITHUB_IAT_TOKEN_PSW}"
         }
         stages {
           stage('Prepare on primary branch') {


### PR DESCRIPTION
Closes #189 .

This PR switches from a github (personal) token usage to a githubapp => "Installation token usage".

Please note that the githubapp infra is used (instead of the updatecli githubapp) as packer init does NOT need any write access.