### PR TITLE
Revert Maven back to 3.8.4

### DIFF
--- a/.auto.pkrvars.hcl
+++ b/.auto.pkrvars.hcl
@@ -1,4 +1,4 @@
-maven_version               = "3.8.5"
+maven_version               = "3.8.4"
 git_version                 = "2.35.1"
 jdk11_version               = "11.0.14+9"
 jdk17_version               = "17.0.2+8"

--- a/scripts/windows-2019-provision.ps1
+++ b/scripts/windows-2019-provision.ps1
@@ -99,7 +99,7 @@ $downloads = [ordered]@{
         };
     };
     'maven' = @{
-        'url' = 'https://apache.osuosl.org/maven/maven-3/{0}/binaries/apache-maven-{0}-bin.zip' -f $env:MAVEN_VERSION;
+        'url' = 'https://archive.apache.org/dist/maven/maven-3/{0}/binaries/apache-maven-{0}-bin.zip' -f $env:MAVEN_VERSION;
         'local' = "$baseDir\maven.zip";
         'expandTo' = $baseDir;
         'path' = '{0}\apache-maven-{1}\bin' -f $baseDir,$env:MAVEN_VERSION;


### PR DESCRIPTION
Reverts jenkins-infra/packer-images#192

Reason: https://github.com/jenkins-infra/helpdesk/issues/2835.