### PR TITLE
Use git 2.35.2

### DIFF
--- a/.auto.pkrvars.hcl
+++ b/.auto.pkrvars.hcl
@@ -1,5 +1,5 @@
 maven_version               = "3.8.4"
-git_version                 = "2.35.1"
+git_version                 = "2.35.2"
 jdk11_version               = "11.0.14+9"
 jdk17_version               = "17.0.2+8"
 jdk8_version                = "8u322-b06"


### PR DESCRIPTION
## Use git 2.35.2

https://github.blog/2022-04-12-git-security-vulnerability-announced/

CVE-2022-24765 - ceiling directory defense
