### PR TITLE
fix(ubuntu) ensure that Docker CE works by adding delay before loading the Docker GPG key to let enough time to the GPG agent to initialize

### DIFF
--- a/scripts/ubuntu-20-provision.sh
+++ b/scripts/ubuntu-20-provision.sh
@@ -68,6 +68,9 @@ function install_docker() {
     gnupg-agent \
     software-properties-common
 
+  # Wait a few seconds to allow the gpg-agent to finish initializing in background
+  sleep 5
+
   #using the local version of the docker public key avoid curl errors
   gpg --batch --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg /tmp/docker.gpg
   echo \


### PR DESCRIPTION
Fix https://github.com/jenkins-infra/helpdesk/issues/2892

Signed-off-by: Damien Duportal <damien.duportal@gmail.com>