### PR TITLE
feat(windows) bump Windows Server to 2022 edition

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -87,7 +87,7 @@ pipeline {
           }
           axis {
             name 'agent_type'
-            values 'ubuntu-20.04', 'windows-2019'
+            values 'ubuntu-20.04', 'windows-2019', 'windows-2022'
           }
           axis {
             name 'compute_type'
@@ -127,6 +127,16 @@ pipeline {
             axis {
               name 'agent_type'
               values 'windows-2019'
+            }
+            axis {
+              name 'compute_type'
+              values 'docker'
+            }
+          }
+          exclude {
+            axis {
+              name 'agent_type'
+              values 'windows-2022'
             }
             axis {
               name 'compute_type'

--- a/build-jenkins-agent-windows.pkr.hcl
+++ b/build-jenkins-agent-windows.pkr.hcl
@@ -50,6 +50,7 @@ build {
   provisioner "windows-restart" {
     max_retries = 3
   }
+  # This provisioner must be the last for Azure builds, after reboots
   provisioner "powershell" {
     only              = ["azure-arm.windows"]
     elevated_user     = local.windows_winrm_user[var.image_type]
@@ -64,15 +65,14 @@ build {
     source      = "./provisioning/EC2-LaunchConfig.json"
     destination = "C:\\ProgramData\\Amazon\\EC2-Windows\\Launch\\Config\\LaunchConfig.json"
   }
+  # This provisioner must be the last for AWS EBS builds, after reboots
   provisioner "powershell" {
     only              = ["amazon-ebs.windows"]
     elevated_user     = local.windows_winrm_user[var.image_type]
     elevated_password = build.Password
     # Ref. https:#docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ec2-windows-user-data.html#user-data-scripts-subsequent
     inline = [
-      "C:\\ProgramData\\Amazon\\EC2-Windows\\Launch\\Scripts\\SendWindowsIsReady.ps1 -Schedule",
-      "C:\\ProgramData\\Amazon\\EC2-Windows\\Launch\\Scripts\\InitializeInstance.ps1 -Schedule",
-      "C:\\ProgramData\\Amazon\\EC2-Windows\\Launch\\Scripts\\SysprepInstance.ps1 -NoShutdown"
+      "if($env:AGENT_OS_VERSION = '2019') { C:\\ProgramData\\Amazon\\EC2-Windows\\Launch\\Scripts\\SendWindowsIsReady.ps1 -Schedule; C:\\ProgramData\\Amazon\\EC2-Windows\\Launch\\Scripts\\InitializeInstance.ps1 -Schedule; C:\\ProgramData\\Amazon\\EC2-Windows\\Launch\\Scripts\\SysprepInstance.ps1 -NoShutdown;};"
     ]
   }
 }

--- a/datasources.pkr.hcl
+++ b/datasources.pkr.hcl
@@ -20,3 +20,14 @@ data "amazon-ami" "windows-2019" {
   owners      = ["amazon"]
   region      = var.aws_region
 }
+
+data "amazon-ami" "windows-2022" {
+  filters = {
+    name                = "Windows_Server-2022-English-Core-ContainersLatest-*"
+    root-device-type    = "ebs"
+    virtualization-type = "hvm"
+  }
+  most_recent = true
+  owners      = ["amazon"]
+  region      = var.aws_region
+}


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2629.

Depends on #221 and #239.

This PR introduces an additional set of VM templates with Windows Server Core 2022 as base OS.

Please note that:
- Docker container is excluded (for now): only AWS and Azure VM templates are added.
- Windows Server 2019 is kept (see comment below for details)