### PR TITLE
feat: copy common GNU tools included with git for Windows in the $baseDir tool folder

### DIFF
--- a/scripts/windows-2019-provision.ps1
+++ b/scripts/windows-2019-provision.ps1
@@ -132,19 +132,30 @@ $downloads = [ordered]@{
             & "mvn.cmd" -v;
         }
     };
-    'git' = @{
+    'git-and-gnu-tools' = @{
         'url' = 'https://github.com/git-for-windows/git/releases/download/v{0}.windows.1/MinGit-{0}-64-bit.zip' -f $env:GIT_WINDOWS_VERSION;
         'local' = "$baseDir\MinGit.zip";
         'expandTo' = "$baseDir\git";
         'postexpand' = {
             & "$baseDir\git\cmd\git.exe" config --system core.autocrlf false;
             & "$baseDir\git\cmd\git.exe" config --system core.longpaths true;
+            # Cherry-pick common GNU tools compiled for Windows included with git
+            # We don't want all of them as it can interfere with native Windows cli tools
+            & Copy-Item -Path "$baseDir\git\usr\bin\awk.exe" -Destination "$baseDir\awk.exe";
+            & Copy-Item -Path "$baseDir\git\usr\bin\grep.exe" -Destination "$baseDir\grep.exe";
+            & Copy-Item -Path "$baseDir\git\usr\bin\rm.exe" -Destination "$baseDir\rm.exe";
+            & Copy-Item -Path "$baseDir\git\usr\bin\sort.exe" -Destination "$baseDir\sort.exe";
         };
         'path' = "$baseDir\git\cmd";
         'cleanuplocal' = 'true';
         'sanityCheck'= {
             & "git.exe" --version;
-        }
+            # GNU tools
+            & "awk.exe" --version;
+            & "grep.exe" --version;
+            & "rm.exe" --version;
+            & "sort.exe" --version;
+        };
     };
     'gitlfs' = @{
         'url' = 'https://github.com/git-lfs/git-lfs/releases/download/v{0}/git-lfs-windows-amd64-v{0}.zip' -f $env:GIT_LFS_VERSION;
@@ -230,7 +241,7 @@ $downloads = [ordered]@{
         'postexpand' = {
             # Installation of Chocolatey
             & "$baseDir\chocolatey.tmp\tools\chocolateyInstall.ps1";
-            # Installation of make for Windows with Chocolatey
+            # Installation of make for Windows with Chocolatey (not included with git)
             & "C:\ProgramData\chocolatey\bin\choco.exe" install make --version "$env:CHOCOLATEY_MAKE_VERSION";
             & Remove-Item -Force -Recurse "$baseDir\chocolatey.tmp";
         };

--- a/scripts/windows-2019-provision.ps1
+++ b/scripts/windows-2019-provision.ps1
@@ -139,7 +139,8 @@ $downloads = [ordered]@{
         'postexpand' = {
             & "$baseDir\git\cmd\git.exe" config --system core.autocrlf false;
             & "$baseDir\git\cmd\git.exe" config --system core.longpaths true;
-            # Cherry-pick common GNU tools compiled for Windows included with git
+            # Cherry-pick common GNU tools compiled for Windows included with Git for Windows
+
             # We don't want all of them as it can interfere with native Windows cli tools
             & Copy-Item -Path "$baseDir\git\usr\bin\awk.exe" -Destination "$baseDir\awk.exe";
             & Copy-Item -Path "$baseDir\git\usr\bin\grep.exe" -Destination "$baseDir\grep.exe";
@@ -155,7 +156,7 @@ $downloads = [ordered]@{
             & "grep.exe" --version;
             & "rm.exe" --version;
             & "sort.exe" --version;
-        };
+        }
     };
     'gitlfs' = @{
         'url' = 'https://github.com/git-lfs/git-lfs/releases/download/v{0}/git-lfs-windows-amd64-v{0}.zip' -f $env:GIT_LFS_VERSION;
@@ -241,7 +242,8 @@ $downloads = [ordered]@{
         'postexpand' = {
             # Installation of Chocolatey
             & "$baseDir\chocolatey.tmp\tools\chocolateyInstall.ps1";
-            # Installation of make for Windows with Chocolatey (not included with git)
+            # Installation of make for Windows with Chocolatey (not included with Git for Windows)
+
             & "C:\ProgramData\chocolatey\bin\choco.exe" install make --version "$env:CHOCOLATEY_MAKE_VERSION";
             & Remove-Item -Force -Recurse "$baseDir\chocolatey.tmp";
         };


### PR DESCRIPTION
Ref: https://github.com/jenkins-infra/helpdesk/issues/2873

Follow-up of https://github.com/jenkins-infra/packer-images/pull/225

Instead of installing other GNU tools via Chocolatey in order to run [a common Makefile](https://github.com/jenkins-infra/pipeline-library/blob/master/resources/io/jenkins/infra/docker/Makefile) to build Docker images on every architecture, we can retrieve almost all needed GNU tools from those included with Git for Windows (notable exception, `make`):

<img width="916" alt="image" src="https://user-images.githubusercontent.com/91831478/168161845-b6a0ef1e-54a5-4393-a528-63489ab41071.png">

I tried move all of them in C:\tools\ but then I retrieved empty responses from almost all common Windows or shell commands, probably due to conflicts between them, hence the cherry-picking.