### PR TITLE
feat(Azure Windows) switch to Windows Server 2019 Core without containers

### DIFF
--- a/build-jenkins-agent-ubuntu.pkr.hcl
+++ b/build-jenkins-agent-ubuntu.pkr.hcl
@@ -9,12 +9,14 @@ build {
   }
 
   source "azure-arm.base" {
-    name            = "ubuntu"
+    name = "ubuntu"
+    # List available offers and publishers with the command `az vm image list --output table`
     image_offer     = "0001-com-ubuntu-server-focal"
     image_publisher = "canonical"
-    image_sku       = "${local.agent_os_version_safe}-lts-gen2"
-    os_type         = "Linux"
-    vm_size         = local.azure_vm_size
+    # List available SKUs with the command `az vm image list-skus --offer 0001-com-ubuntu-server-focal --location eastus --publisher canonical --output table`
+    image_sku = "${local.agent_os_version_safe}-lts-gen2"
+    os_type   = "Linux"
+    vm_size   = local.azure_vm_size
   }
 
   # Docker Ubuntu image are missing required tools: let's install it as a preliminary

--- a/build-jenkins-agent-windows.pkr.hcl
+++ b/build-jenkins-agent-windows.pkr.hcl
@@ -10,11 +10,13 @@ build {
   }
 
   source "azure-arm.base" {
-    name            = "windows"
-    communicator    = "winrm"
+    name         = "windows"
+    communicator = "winrm"
+    # List available offers and publishers with the command `az vm image list --output table`
     image_offer     = "WindowsServer"
     image_publisher = "MicrosoftWindowsServer"
-    image_sku       = "${var.agent_os_version}-datacenter-core-with-containers-smalldisk-g2"
+    # List available SKUs with the command `az vm image list-skus --offer WindowsServer --location eastus --publisher MicrosoftWindowsServer --output table`
+    image_sku       = "${var.agent_os_version}-datacenter-core-smalldisk-g2"
     vm_size         = local.azure_vm_size
     os_type         = "Windows"
     os_disk_size_gb = local.windows_disk_size_gb

--- a/provisioning/windows-provision.ps1
+++ b/provisioning/windows-provision.ps1
@@ -83,7 +83,7 @@ try {
     Write-Output "== Setting up Docker Module..."
     Install-Module -Name DockerMsftProvider -Repository PSGallery -Force
     Write-Output "== Setting up Docker Package..."
-    Install-Package -Name docker -ProviderName DockerMsftProvider
+    Install-Package -Name docker -ProviderName DockerMsftProvider -Force
     ## A reboot is required before being able to use start containers (but we don't need to).
 }
 

--- a/provisioning/windows-provision.ps1
+++ b/provisioning/windows-provision.ps1
@@ -66,8 +66,7 @@ Function AddToPathEnv($path) {
 }
 
 # Install OpenSSH (from Windows Features)
-Write-Output "== Setting up OpenSSH Server"
-Write-Host "== (host) setting up OpenSSH Server"
+Write-Output "= Setting up OpenSSH Server"
 
 Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
 Set-Service -Name sshd -StartupType 'Automatic'
@@ -78,8 +77,12 @@ New-NetFirewallRule -Name sshd -DisplayName 'OpenSSH Server (sshd)' -Enabled Tru
 try {
     docker -v ## client version only
 } catch {
+    Write-Output "= Docker not found: installing..."
+    Write-Output "== Setting up Nuget..."
     Install-PackageProvider -Name NuGet -Force
+    Write-Output "== Setting up Docker Module..."
     Install-Module -Name DockerMsftProvider -Repository PSGallery -Force
+    Write-Output "== Setting up Docker Package..."
     Install-Package -Name docker -ProviderName DockerMsftProvider
     ## A reboot is required before being able to use start containers (but we don't need to).
 }

--- a/provisioning/windows-provision.ps1
+++ b/provisioning/windows-provision.ps1
@@ -74,6 +74,16 @@ Set-Service -Name sshd -StartupType 'Automatic'
 Start-Service sshd
 New-NetFirewallRule -Name sshd -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22 | Out-Null
 
+# Install Docker-CE if missing
+try {
+    docker -v ## client version only
+} catch {
+    Install-PackageProvider -Name NuGet -Force
+    Install-Module -Name DockerMsftProvider -Repository PSGallery -Force
+    Install-Package -Name docker -ProviderName DockerMsftProvider
+    ## A reboot is required before being able to use start containers (but we don't need to).
+}
+
 ## Prepare Tools Installation
 $baseDir = 'C:\tools'
 New-Item -ItemType Directory -Path $baseDir -Force | Out-Null


### PR DESCRIPTION
This PR comes from https://github.com/jenkins-infra/helpdesk/issues/2942.

It changes the Azure SKU to a Windows Server 2019 without containers and takes care of installing Docker CE on any windows when it is not detected.