### PR TITLE
fix: install git for Windows with choco so we can chose to not install Git Credential Manager

### DIFF
--- a/provisioning/windows-provision.ps1
+++ b/provisioning/windows-provision.ps1
@@ -132,33 +132,6 @@ $downloads = [ordered]@{
             & "mvn.cmd" -v;
         }
     };
-    'git' = @{
-        'url' = 'https://github.com/git-for-windows/git/releases/download/v{0}.windows.1/MinGit-{0}-64-bit.zip' -f $env:GIT_WINDOWS_VERSION;
-        'local' = "$baseDir\MinGit.zip";
-        'expandTo' = "$baseDir\git";
-        'postExpand' = {
-            & "$baseDir\git\cmd\git.exe" config --system core.autocrlf false;
-            & "$baseDir\git\cmd\git.exe" config --system core.longpaths true;
-        };
-        'path' = "$baseDir\git\cmd";
-        'cleanupLocal' = 'true';
-        'sanityCheck'= {
-            & "git.exe" --version;
-        }
-    };
-    'gitlfs' = @{
-        'url' = 'https://github.com/git-lfs/git-lfs/releases/download/v{0}/git-lfs-windows-amd64-v{0}.zip' -f $env:GIT_LFS_VERSION;
-        'local' = "$baseDir\GitLfs.zip";
-        'expandTo' = "$baseDir\git\mingw64\bin";
-        'postExpand' = {
-            & "$baseDir\git\cmd\git.exe" lfs install;
-        };
-        'path' = "$baseDir\git\mingw64\bin";
-        'cleanupLocal' = 'true';
-        'sanityCheck'= {
-            & "git-lfs.exe" version;
-        }
-    };
     'dockercompose' = @{
         'url' = 'https://github.com/docker/compose/releases/download/v{0}/docker-compose-Windows-x86_64.exe' -f $env:COMPOSE_VERSION;
         'local' = "$baseDir\docker-compose.exe"
@@ -237,12 +210,18 @@ $downloads = [ordered]@{
         'postInstall' = {
             # Installation of make for Windows with Chocolatey
             & "choco.exe" install make --yes --no-progress --version "$env:CHOCOLATEY_MAKE_VERSION";
+            # Installation of git for Windows (include git-lfs), see https://community.chocolatey.org/packages/git
+            & "choco.exe" install git --yes --no-progress --params "/NoAutoCrlf /NoCredentialManager";
+            # git additional configuration
+            & "git.exe" config --system core.longpaths true;
             # Installation of Cygwin with Chocolatey
             & "choco.exe" install cygwin --yes --no-progress;
         };
         'sanityCheck'= {
             & "choco.exe";
             & "make.exe" -version;
+            & "git.exe" --version;
+            & "git-lfs" --version;
         }
     };
 }


### PR DESCRIPTION
Related: https://github.com/jenkins-infra/helpdesk/issues/2873