### PR TITLE
fix: no cygwin

### DIFF
--- a/provisioning/windows-provision.ps1
+++ b/provisioning/windows-provision.ps1
@@ -153,7 +153,8 @@ $downloads = [ordered]@{
             & "$baseDir\git\cmd\git.exe" config --system core.autocrlf false;
             & "$baseDir\git\cmd\git.exe" config --system core.longpaths true;
         };
-        'path' = "$baseDir\git\cmd";
+        # git cmd and gnu tools included with git as paths
+        'path' = "$baseDir\git\cmd;$baseDir\git\usr\bin";
         'cleanupLocal' = 'true';
         'sanityCheck'= {
             & "git.exe" --version;

--- a/provisioning/windows-provision.ps1
+++ b/provisioning/windows-provision.ps1
@@ -253,14 +253,10 @@ $downloads = [ordered]@{
         'postInstall' = {
             # Installation of make for Windows
             & "choco.exe" install make --yes --no-progress --limit-output --fail-on-error-output;
-            # Installation of cygwin
-            & "choco.exe" install cygwin --yes --no-progress --limit-output --fail-on-error-output;
         };
         'sanityCheck'= {
             & "choco.exe";
             & "make.exe" -version;
-            # List cygwin tools tools folder (not available in the PATH)
-            & Get-ChildItem -Path "$baseDir\cygwin\bin\" -Name;
         }
     };
 }


### PR DESCRIPTION
It seems there is a collision between them and the tools included with git for Windows when used in the buildDockerAndPublishImage shared pipeline lib:

> Cloning into 'private-repo'...
>       0 [main] cat (2272) C:\tools\git\usr\bin\cat.exe: *** fatal error - cygheap base mismatch detected - 0x180348408/0x18034C408.
> This problem is probably due to using incompatible versions of the cygwin DLL.

Related: https://github.com/jenkins-infra/helpdesk/issues/2873