### PR TITLE
hotfix(windows-2019) pin to 2022 05 11 build on AWS 

### DIFF
--- a/datasources.pkr.hcl
+++ b/datasources.pkr.hcl
@@ -12,7 +12,9 @@ data "amazon-ami" "ubuntu-20_04" {
 
 data "amazon-ami" "windows-2019" {
   filters = {
-    name                = "Windows_Server-2019-English-Core-ContainersLatest-*"
+    # Pinned to 20220511 version because of https://github.com/jenkins-infra/packer-images/issues/253
+    # TODO: unpin once 202206* is released on AWS and proven fixed
+    name                = "Windows_Server-2019-English-Core-ContainersLatest-2022.05.11*"
     root-device-type    = "ebs"
     virtualization-type = "hvm"
   }


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/packer-images/issues/253

This PR is a hotfix to ensure that  we can keep building a valid Windows Server 2019 in AWS.

- Comment added in the packer file
- Since we are applying all available Windows updates, the resulting image will be fresh and up to date. Just longer to build.
- We might use updatecli on a subsequent PR that would extract the latest image and open PR, so we can test. For Windows Server on AWS, it's ~2 updates per month so it could be sustainable.