### PR TITLE
fix: remoting manifest

### DIFF
--- a/updatecli/updatecli.d/jenkins-remoting.yml
+++ b/updatecli/updatecli.d/jenkins-remoting.yml
@@ -22,8 +22,6 @@ sources:
       repository: "remoting"
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
-      versionfilter:
-        kind: semver
 
 targets:
   updateVersion:


### PR DESCRIPTION
Remoting releases don't follow semver anymore: https://github.com/jenkinsci/remoting/releases