### PR TITLE
fix: release Docker image for Linux

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,6 +1,6 @@
-def isPrimary = false
+def isPrimaryBranch = false
 if (env.BRANCH_IS_PRIMARY) {
-  isPrimary = true
+  isPrimaryBranch = true
   properties([
     buildDiscarder(logRotator(numToKeepStr: '10')),
     // Daily build is enough: only the tagged build would generate downstream PRs on jenkins-infra
@@ -202,7 +202,7 @@ pipeline {
           stage('Publish Docker image') {
             steps {
               script {
-                if (isPrimary && env.TAG_NAME && (env.compute_type == 'docker')) {
+                if (isPrimaryBranch && env.TAG_NAME && (env.compute_type == 'docker')) {
                   infra.withDockerPushCredentials {
                     def dockerImage = "jenkinsciinfra/jenkins-agent-${env.agent_type}:${env.TAG_NAME}"
                     docker push dockerImage

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,5 +1,6 @@
-
+def isPrimary = false
 if (env.BRANCH_IS_PRIMARY) {
+  isPrimary = true
   properties([
     buildDiscarder(logRotator(numToKeepStr: '10')),
     // Daily build is enough: only the tagged build would generate downstream PRs on jenkins-infra
@@ -201,8 +202,8 @@ pipeline {
           stage('Publish Docker image') {
             steps {
               script {
-                if ((env.BRANCH_IS_PRIMARY) && (env.TAG_NAME)) {
-                  infra.withDockerCredentials {
+                if (isPrimary && env.TAG_NAME && (env.compute_type == 'docker')) {
+                  infra.withDockerPushCredentials {
                     def dockerImage = "jenkinsciinfra/jenkins-agent-${env.agent_type}:${env.TAG_NAME}"
                     docker push dockerImage
                   }


### PR DESCRIPTION
Follow-up of https://github.com/jenkins-infra/packer-images/pull/287

Use correct credentials (needs https://github.com/jenkins-infra/kubernetes-management/pull/2644)
Set isPrimary variable as env.BRANCH_IS_PRIMARY doesn't seem to be available in scripted
Add a condition on compute_type for the 'publish docker image' stage

Ref: https://github.com/jenkins-infra/packer-images/issues/282