### PR TITLE
chore(azure builders) enable async resources deletion

### DIFF
--- a/build-jenkins-agent-ubuntu.pkr.hcl
+++ b/build-jenkins-agent-ubuntu.pkr.hcl
@@ -17,6 +17,8 @@ build {
     image_sku = "${local.agent_os_version_safe}-lts-gen2"
     os_type   = "Linux"
     vm_size   = local.azure_vm_size
+    # Delete resources asynchronously (faster build and the garbage collector takes care of failed deletion)
+    async_resourcegroup_delete = true
   }
 
   provisioner "shell" {

--- a/build-jenkins-agent-windows.pkr.hcl
+++ b/build-jenkins-agent-windows.pkr.hcl
@@ -24,6 +24,8 @@ build {
     winrm_timeout   = "20m"
     winrm_use_ssl   = true
     winrm_username  = local.windows_winrm_user[var.image_type]
+    # Delete resources asynchronously (faster build and the garbage collector takes care of failed deletion)
+    async_resourcegroup_delete = true
   }
 
   ## Why repeating? https://github.com/rgl/packer-plugin-windows-update/issues/90#issuecomment-842569865


### PR DESCRIPTION
Ref. https://www.packer.io/plugins/builders/azure/arm#async_resourcegroup_delete

We have, quite often, error (go panic) thrown by the azure packer plugin.

This repository used to have this setting enabled (ref. https://github.com/jenkins-infra/packer-images/pull/61/files) but it was removed at a given point in time, because there was no clud resource GCs.
