### PR TITLE
chore(updatecli) fix vagrant manifest by adding a condition to check for chocolatey package to be published before opening a PR

### DIFF
--- a/updatecli/updatecli.d/vagrant.yml
+++ b/updatecli/updatecli.d/vagrant.yml
@@ -25,6 +25,15 @@ sources:
       versionfilter:
         kind: semver
 
+conditions:
+  ## Only check for chocolatey package: ASDF package is always faster than chocolatey to publish + both packages are relying on hashicorp
+  checkForChocolateyPackage:
+    kind: shell
+    disablesourceinput: true # Do not pass source as argument to the command line
+    spec:
+      command: curl https://community.chocolatey.org/packages/vagrant/{{ source "lastReleaseVersion" }} --silent --show-error --location --fail --output /dev/null
+
+
 targets:
   updateVersion:
     name: "Update the vagrant version in the provision-env.yml file"


### PR DESCRIPTION
This PR fixes #311 .