### PR TITLE
feat: add datadog-agent v7 (latest)

### DIFF
--- a/provisioning/windows-provision.ps1
+++ b/provisioning/windows-provision.ps1
@@ -259,7 +259,7 @@ $downloads = [ordered]@{
             & "choco.exe" install ruby --yes --no-progress --limit-output --fail-on-error-output --version "${env:RUBY_VERSION}.1";
             & "choco.exe" install yq --yes --no-progress --limit-output --fail-on-error-output --version "${env:YQ_VERSION}";
             & "choco.exe" install packer --yes --no-progress --limit-output --fail-on-error-output --version "${env:PACKER_VERSION}";
-
+            & "choco.exe" install datadog-agent --yes --no-progress --limit-output --fail-on-error-output;
         };
         'sanityCheck'= {
             & "choco.exe";
@@ -269,6 +269,7 @@ $downloads = [ordered]@{
             & "$baseDir\ruby26\bin\bundle" -v;
             & "yq.exe" --version;
             & "packer.exe" --version;
+            & "datadog-agent.exe" version;
         }
     };
 }

--- a/provisioning/windows-provision.ps1
+++ b/provisioning/windows-provision.ps1
@@ -264,12 +264,10 @@ $downloads = [ordered]@{
         'sanityCheck'= {
             & "choco.exe";
             & "make.exe" -version;
-            # & "vagrant.exe" --version;
             & "$baseDir\ruby26\bin\ruby.exe" -v;
             & "$baseDir\ruby26\bin\bundle" -v;
             & "yq.exe" --version;
             & "packer.exe" --version;
-            & "datadog-agent.exe" version;
         }
     };
 }


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2980, this PR add the latest datadog-agent available on both Ubuntu and Windows.

Please note that:

- Latest version is used (APT package on Ubuntu, Chocolatey package on Windows)
- The associated service is not started neither enabled: that would be the role of the system that will start instances (Jenkins EC2 plugin, Jenkins Azure VM plugin)