### PR TITLE
fix(ubuntu - docker) set default user to "jenkins" (UID: 1001)

### DIFF
--- a/sources.pkr.hcl
+++ b/sources.pkr.hcl
@@ -87,5 +87,6 @@ source "docker" "base" {
     "ENV AGENT_WORKDIR=/home/jenkins/agent",
     "WORKDIR /home/jenkins",
     "ENTRYPOINT [\"/usr/local/bin/jenkins-agent\"]",
+    "USER jenkins",
   ]
 }


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3132

The associated UID is `1001`: https://github.com/jenkins-infra/packer-images/blob/main/provisioning/ubuntu-provision.sh#L14. it's the same as VMs, but is a change from previous container images.