### PR TITLE
fix(ubuntu) add `docker-buildx-plugin` package (orphaned from `docker-ce-cli` since Docker-CE 23.x)

### DIFF
--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -666,7 +666,9 @@ function sanity_check() {
   && echo 'datadog-agent version:' \
   && datadog-agent version \
   && echo 'docker version:' \
-  && docker -v  \
+  && docker -v \
+  && echo 'docker BuildX version:' \
+  && docker buildx version \
   && echo 'docker-compose version:' \
   && docker-compose -v \
   && echo 'gh version:' \

--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -176,7 +176,7 @@ function install_docker() {
     lsb-release \
     gnupg-agent \
     software-properties-common
-
+  
   gpg --batch --yes --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg /tmp/docker.gpg
 
   echo \
@@ -192,7 +192,7 @@ Pin-Priority: 1001
 " | tee /etc/apt/preferences.d/docker-ce
 
   # Install pinned version
-  apt-get install --yes --no-install-recommends docker-ce
+  apt-get install --yes --no-install-recommends docker-ce docker-ce-cli docker-buildx-plugin
 
   # Allow the default user to use Docker. https://docs.docker.com/engine/install/linux-postinstall/
   # Please note that it gives effectively full root permissions to this user so these compute instances must be ephemeral


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3400

Since [Docker 23.x](https://docs.docker.com/engine/release-notes/23.0/) line (that we added in https://github.com/jenkins-infra/packer-images/pull/500), the [Docker BuildX plugin](https://docs.docker.com/build/install-buildx/) does not seem to be part of the default `docker-ce-cli` package in Ubuntu, but it is now a separated package.

As we install with the `--no-install-recommends`, it led to buildx not being present since the [`0.58.0`](https://github.com/jenkins-infra/packer-images/releases/tag/0.58.0) release.

This PR fixes the problem by following the new Docker's documentation instructions (updated in https://github.com/docker/docs/commit/72d3016e81b93c4ce4e6c8e7b3400ac042d16a26) by adding the required package.

Tested from the `0.60.0` container locally:

```console
docker run --platform=linux/amd64 -u root --rm -ti --entrypoint=bash jenkinsciinfra/jenkins-agent-ubuntu-20.04:0.60.0
root@b12d74efde55:/home/jenkins# apt update
Hit:1 http://ppa.launchpad.net/git-core/ppa/ubuntu focal InRelease                                                                                                                                                                   
Ign:2 https://apt.datadoghq.com stable InRelease                                                                                                                                                                                     
Hit:3 https://download.docker.com/linux/ubuntu focal InRelease                                                                                                                                                                       
Hit:4 https://apt.releases.hashicorp.com focal InRelease                                                        
Hit:5 http://ppa.launchpad.net/phd/chromium-browser/ubuntu focal InRelease                                      
Hit:6 https://apt.datadoghq.com stable Release                                                                  
Hit:7 http://archive.ubuntu.com/ubuntu focal InRelease              
Get:8 http://security.ubuntu.com/ubuntu focal-security InRelease [114 kB]
Get:9 http://archive.ubuntu.com/ubuntu focal-updates InRelease [114 kB]
Get:10 http://archive.ubuntu.com/ubuntu focal-backports InRelease [108 kB]
Fetched 336 kB in 5s (73.4 kB/s)   
Reading package lists... Done
Building dependency tree       
Reading state information... Done
All packages are up to date.
root@b12d74efde55:/home/jenkins# cd
root@b12d74efde55:~# apt-get install --yes --no-install-recommends docker-ce docker-ce-cli docker-buildx-plugin
Reading package lists... Done
Building dependency tree       
Reading state information... Done
docker-ce-cli is already the newest version (5:23.0.1-1~ubuntu.20.04~focal).
docker-ce-cli set to manually installed.
docker-ce is already the newest version (5:23.0.1-1~ubuntu.20.04~focal).
The following NEW packages will be installed:
  docker-buildx-plugin
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
Need to get 25.9 MB of archives.
After this operation, 70.5 MB of additional disk space will be used.
Get:1 https://download.docker.com/linux/ubuntu focal/stable amd64 docker-buildx-plugin amd64 0.10.2-1~ubuntu.20.04~focal [25.9 MB]
Fetched 25.9 MB in 2s (15.5 MB/s)                
debconf: delaying package configuration, since apt-utils is not installed
Selecting previously unselected package docker-buildx-plugin.
(Reading database ... 68827 files and directories currently installed.)
Preparing to unpack .../docker-buildx-plugin_0.10.2-1~ubuntu.20.04~focal_amd64.deb ...
Unpacking docker-buildx-plugin (0.10.2-1~ubuntu.20.04~focal) ...
Setting up docker-buildx-plugin (0.10.2-1~ubuntu.20.04~focal) ...
root@b12d74efde55:~# docker buildx create --help

Usage:  docker buildx create [OPTIONS] [CONTEXT|ENDPOINT]

Create a new builder instance

Options:
      --append                   Append a node to builder instead of changing it
      --bootstrap                Boot builder after creation
      --buildkitd-flags string   Flags for buildkitd daemon
      --config string            BuildKit config file
      --driver string            Driver to use (available: "docker-container", "kubernetes", "remote")
      --driver-opt stringArray   Options for the driver
      --leave                    Remove a node from builder instead of changing it
      --name string              Builder instance name
      --node string              Create/modify node with given name
      --platform stringArray     Fixed platforms for current node
      --use                      Set the current builder instance
root@b12d74efde55:~# exit
```