### PR TITLE
fix: don't use small disks VM templates for Azure Windows templates

### DIFF
--- a/build-jenkins-agent-windows.pkr.hcl
+++ b/build-jenkins-agent-windows.pkr.hcl
@@ -16,7 +16,7 @@ build {
     image_offer     = "WindowsServer"
     image_publisher = "MicrosoftWindowsServer"
     # List available SKUs with the command `az vm image list-skus --offer WindowsServer --location eastus --publisher MicrosoftWindowsServer --output table`
-    image_sku       = "${var.agent_os_version}-datacenter-core-smalldisk-g2"
+    image_sku       = "${var.agent_os_version}-datacenter-core-g2"
     vm_size         = local.azure_vm_size
     os_type         = "Windows"
     os_disk_size_gb = local.windows_disk_size_gb


### PR DESCRIPTION
Using the "smalldisk" template, we were generating VMs with 30Go OS disk:

```
C:\Users\smallDiskUser>for /f "tokens=1-3" %a in ('WMIC LOGICALDISK GET FreeSpace^,Name^,Size ^|FINDSTR /I /V "Name"') do @echo wsh.echo "%b" ^& " free=" ^& FormatNumber^(cdbl^(%a^)/1024/1024/1024, 2^)^& " GiB"^& " size=" ^& FormatNumber^(cdbl^(%c^)/1024/1024/1024, 2^)^& " GiB" > %temp%\tmp.vbs & @if not "%c"=="" @echo( & @cscript //nologo %temp%\tmp.vbs & del %temp%\tmp.vbs

C: free=18.32 GiB size=29.45 GiB

D: free=14.07 GiB size=16.00 GiB
```

Tested on a VM manually spawned with `2019-datacenter-core-g2` as base template, we're getting a bigger OS disk:
```
C:\Users\noSmallDiskUser> for /f "tokens=1-3" %a in ('WMIC LOGICALDISK GET FreeSpace^,Name^,Size ^|FINDSTR /I /V "Name"') do @echo wsh.echo "%b" ^& " free=" ^& FormatNumber^(cdbl^(%a^)/1024/1024/1024, 2^)^& " GiB"^& " size=" ^& FormatNumber^(cdbl^(%c^)/1024/1024/1024, 2^)^& " GiB" > %temp%\tmp.vbs & @if not "%c"=="" @echo( & @cscript //nologo %temp%\tmp.vbs & del %temp%\tmp.vbs

C: free=120.53 GiB size=126.45 GiB

D: free=14.07 GiB size=16.00 GiB
```

Ref: https://github.com/jenkins-infra/helpdesk/issues/3359