### PR TITLE
chore(cleanup AWS) garbage collect EC2 snapshots older than 1 year on `us-east-2`

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -100,6 +100,7 @@ pipeline {
             catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
               sh './cleanup/aws.sh'
               sh './cleanup/aws_images.sh'
+              sh './cleanup/aws_snapshots.sh'
             }
           }
         }

--- a/cleanup/aws_images.sh
+++ b/cleanup/aws_images.sh
@@ -41,7 +41,7 @@ aws sts get-caller-identity >/dev/null || \
 
 ## STEP 1
 ## Remove images older than 1 month from dev
-INSTANCE_IDS="$(aws ec2 describe-images --owners self  --filters 'Name=tag:build_type,Values=dev' \
+INSTANCE_IDS="$(aws ec2 describe-images --owners self --filters 'Name=tag:build_type,Values=dev' \
   --query 'Images[?CreationDate<=`'"${lastmonthdate}"'`][].ImageId' | jq -r '.[]' | xargs)"
 
 if [ -n "${INSTANCE_IDS}" ]

--- a/cleanup/aws_images.sh
+++ b/cleanup/aws_images.sh
@@ -40,7 +40,7 @@ aws sts get-caller-identity >/dev/null || \
   { echo "[ERROR] Unable to request the AWS API: the command 'sts get-caller-identity' failed. Please check your AWS credentials"; exit 1; }
 
 ## STEP 1
-## Remove images older than 1 month from dev
+## Remove images older than <timeshift_month> month(s) from dev
 INSTANCE_IDS="$(aws ec2 describe-images --owners self --filters 'Name=tag:build_type,Values=dev' \
   --query 'Images[?CreationDate<=`'"${lastmonthdate}"'`][].ImageId' | jq -r '.[]' | xargs)"
 

--- a/cleanup/aws_snapshots.sh
+++ b/cleanup/aws_snapshots.sh
@@ -24,15 +24,14 @@ do
   command -v "${cli}" >/dev/null || { echo "[ERROR] no '${cli}' command found."; exit 1; }
 done
 
-## When is last month exactly?
-lastmonthdate=""
-timeshift_month="1"
+start_time_threshold=""
+timeshift_month="12"
 if date -v-${timeshift_month}m > /dev/null 2>&1; then
     # BSD systems (Mac OS X)
-    lastmonthdate="$(date -v-${timeshift_month}m +%Y-%m-%d)"
+    start_time_threshold="$(date -v-${timeshift_month}m +%Y-%m-%d)"
 else
     # GNU systems (Linux)
-    lastmonthdate="$(date --date="-${timeshift_month} months" +%Y-%m-%d)"
+    start_time_threshold="$(date --date="-${timeshift_month} months" +%Y-%m-%d)"
 fi
 
 ## Check for aws API reachibility (is it configured?)
@@ -43,7 +42,7 @@ aws sts get-caller-identity >/dev/null || \
 ## Remove snapshots older than 1 month from dev
 snapshot_ids="$(aws ec2 describe-snapshots \
   --owner-ids self \
-  --query "Snapshots[?StartTime<='${lastmonthdate}'].[SnapshotId]" \
+  --query "Snapshots[?StartTime<='${start_time_threshold}'].[SnapshotId]" \
   --no-paginate \
   --region=us-east-2 \
   | jq -r '.[][]' | xargs)"

--- a/cleanup/aws_snapshots.sh
+++ b/cleanup/aws_snapshots.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+run_aws_ec2_command() {
+  # Check the DRYRUN environment variable
+  if [ "${DRYRUN:-true}" = "false" ] || [ "${DRYRUN:-true}" = "no" ]
+  then
+    # Execute command "as it"
+    aws ec2 "$@"
+  else
+    # Execute command with the "--dry-run"
+    ec2_subcommand="$1"
+    shift
+    echo "== DRY RUN:"
+    echo "aws ec2 ${ec2_subcommand} --dry-run" "$@"
+    aws ec2 "${ec2_subcommand}" --dry-run "$@" 2>&1 | grep -v 'Request would have succeeded' || true
+  fi
+}
+
+## Check for presence of required CLIs
+for cli in aws jq date xargs
+do
+  command -v "${cli}" >/dev/null || { echo "[ERROR] no '${cli}' command found."; exit 1; }
+done
+
+## When is last month exactly?
+lastmonthdate=""
+timeshift_month="1"
+if date -v-${timeshift_month}m > /dev/null 2>&1; then
+    # BSD systems (Mac OS X)
+    lastmonthdate="$(date -v-${timeshift_month}m +%Y-%m-%d)"
+else
+    # GNU systems (Linux)
+    lastmonthdate="$(date --date="-${timeshift_month} months" +%Y-%m-%d)"
+fi
+
+## Check for aws API reachibility (is it configured?)
+aws sts get-caller-identity >/dev/null || \
+  { echo "[ERROR] Unable to request the AWS API: the command 'sts get-caller-identity' failed. Please check your AWS credentials"; exit 1; }
+
+## STEP 1
+## Remove snapshots older than 1 month from dev
+snapshot_ids="$(aws ec2 describe-snapshots \
+  --owner-ids self \
+  --query "Snapshots[?StartTime<='${lastmonthdate}'].[SnapshotId]" \
+  --no-paginate \
+  --region=us-east-2 \
+  | jq -r '.[][]' | xargs)"
+
+if [ -n "${snapshot_ids}" ]
+then
+  #shellcheck disable=SC2086
+  #has to run on each instance
+  cpt="0"
+  for thesnapshot_id in ${snapshot_ids}
+  do
+    run_aws_ec2_command delete-snapshot --snapshot-id "${thesnapshot_id}"
+    ((cpt=cpt+1))
+  done
+
+  if [ "${DRYRUN:-true}" = "false" ] || [ "${DRYRUN:-true}" = "no" ]
+  then
+    echo "== $cpt snapshots have been deleted"
+  else
+    echo "==DRYRUN $cpt snapshots would have been deleted"
+  fi
+else
+  echo "== No dangling snapshots found to delete."
+fi
+
+echo "== AWS Packer Cleanup SNAPSHOTS finished."

--- a/cleanup/aws_snapshots.sh
+++ b/cleanup/aws_snapshots.sh
@@ -39,7 +39,7 @@ aws sts get-caller-identity >/dev/null || \
   { echo "[ERROR] Unable to request the AWS API: the command 'sts get-caller-identity' failed. Please check your AWS credentials"; exit 1; }
 
 ## STEP 1
-## Remove snapshots older than 1 month from dev
+## Remove snapshots older than <timeshift_month> month(s) from dev
 snapshot_ids="$(aws ec2 describe-snapshots \
   --owner-ids self \
   --query "Snapshots[?StartTime<='${start_time_threshold}'].[SnapshotId]" \


### PR DESCRIPTION
Implements https://github.com/jenkins-infra/helpdesk/issues/2846#issuecomment-1120206965, in the context of https://github.com/jenkins-infra/helpdesk/issues/3502.

This PR add a GC for AWS snapshots, restricted to `us-east-2` .