### PR TITLE
Chore/fixup cleanup aws snapshots

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -54,7 +54,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: jnlp
-      image: jenkinsciinfra/hashicorp-tools:latest
+      image: jenkinsciinfra/jenkins-agent-ubuntu-22.04:latest
 '''
 
 pipeline {


### PR DESCRIPTION
Fixup of https://github.com/jenkins-infra/packer-images/pull/587

- Switches to the "all in one" container image to allow using `parallel` CLI
  - Shell tools such as `jq`, `xargs` are present
  - Cloud CLIs for AWS (`aws`)  and Azure (`az`)  are present and kept up to date