### PR TITLE
chore(cleanup AWS images) ensure staging images older than 7 days are removed

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -99,7 +99,8 @@ pipeline {
           steps {
             catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
               sh './cleanup/aws.sh'
-              sh './cleanup/aws_images.sh'
+              sh './cleanup/aws_images.sh 1 dev'
+              sh './cleanup/aws_images.sh 7 staging'
               sh './cleanup/aws_snapshots.sh'
             }
           }


### PR DESCRIPTION
Implements the "Delete staging images older than 1 week" from https://github.com/jenkins-infra/helpdesk/issues/2846

This PR introduces 3 (linked) changes:

- Parameterized the `cleanup/aws_images.sh` script to allow passing parameters
  - `$1` specifies the number of days for which the AMIs older than this threshold will be removed. Defaults to `1` (day).
  - `$2` specifies the build_type for AMIs to check for deletion. Defaults to `dev`.
- Enable parallelization, like in #589 to ensure there are NO fail fast
- Enable cleanup of staging images older than 7 days 