### PR TITLE
chore(cleanup AWS images) remove AMI with build_type=prod older than 2 months

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -101,6 +101,7 @@ pipeline {
               sh './cleanup/aws.sh'
               sh './cleanup/aws_images.sh 1 dev'
               sh './cleanup/aws_images.sh 7 staging'
+              sh './cleanup/aws_images.sh 60 prod'
               sh './cleanup/aws_snapshots.sh'
             }
           }


### PR DESCRIPTION

Ref. https://github.com/jenkins-infra/helpdesk/issues/2846