### PR TITLE
cleanup: stop building EC2 Linux amd64 and EC2 Windows

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -165,6 +165,19 @@ pipeline {
           }
         }
         excludes {
+          /**
+          Since https://github.com/jenkins-infra/helpdesk/issues/3421 and https://github.com/jenkins-infra/helpdesk/issues/3502, EC2 is only used for Linux + `arm64` VMs.
+          **/
+          exclude {
+            axis {
+              name 'cpu_architecture'
+              values 'amd64'
+            }
+            axis {
+              name 'compute_type'
+              values 'amazon-ebs'
+            }
+          }
           // Do NOT build ARM images in Azure
           exclude {
             axis {


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3502

Since https://github.com/jenkins-infra/helpdesk/issues/3421, we have disabled the EC2 VM agents for Linux `x86` and Windows (all types).

Better to avoid wasting credits: this PR disable these build types.

Please note that it does NOT remove the underlying Packer configuration