### PR TITLE
chore: ensure that spot instances are used for packer builds

### DIFF
--- a/build-jenkins-agent-ubuntu.pkr.hcl
+++ b/build-jenkins-agent-ubuntu.pkr.hcl
@@ -16,7 +16,6 @@ build {
     # List available SKUs with the command `az vm image list-skus --offer 0001-com-ubuntu-server-jammy --location eastus --publisher canonical --output table`
     image_sku = "${local.agent_os_version_safe}-lts-gen2"
     os_type   = "Linux"
-    vm_size   = local.azure_vm_size
   }
 
   provisioner "shell" {

--- a/build-jenkins-agent-windows.pkr.hcl
+++ b/build-jenkins-agent-windows.pkr.hcl
@@ -17,7 +17,6 @@ build {
     image_publisher = "MicrosoftWindowsServer"
     # List available SKUs with the command `az vm image list-skus --offer WindowsServer --location eastus --publisher MicrosoftWindowsServer --output table`
     image_sku       = "${var.agent_os_version}-datacenter-core-g2"
-    vm_size         = local.azure_vm_size
     os_type         = "Windows"
     os_disk_size_gb = local.windows_disk_size_gb
     winrm_insecure  = true
@@ -34,7 +33,7 @@ build {
 
   # Installing Docker requires a restart: this first call to the installation script will prepare requirements
   provisioner "powershell" {
-    pause_before = "1m"
+    pause_before      = "1m"
     environment_vars  = local.provisioning_env_vars
     elevated_user     = local.windows_winrm_user[var.image_type]
     elevated_password = build.Password
@@ -49,7 +48,7 @@ build {
 
   # Install Docker-CE with Container feature loaded
   provisioner "powershell" {
-    pause_before = "1m"
+    pause_before      = "1m"
     environment_vars  = local.provisioning_env_vars
     elevated_user     = local.windows_winrm_user[var.image_type]
     elevated_password = build.Password

--- a/locals.pkr.hcl
+++ b/locals.pkr.hcl
@@ -3,9 +3,11 @@ locals {
   agent                 = format("%s-%s", var.agent_os_type, var.agent_os_version)
   agent_os_version_safe = replace(var.agent_os_version, ".", "_")
   image_name            = format("jenkins-agent-%s-%s", var.agent_os_type, var.agent_os_version)
-  aws_instance_type = {
-    "amd64" = "t3a.xlarge" # 4 vCPU AMD / 16 GB / $0.1504 - https://aws.amazon.com/fr/ec2/instance-types/t3/#Product_Details
-    "arm64" = "t4g.xlarge" # 4 vCPU / 16 GB / $0.1344 - https://aws.amazon.com/fr/ec2/instance-types/t4/#Product_Details
+  aws_spot_instance_types = {
+    # 4 vCPU x86 / 16 GB / $0.1504 - https://aws.amazon.com/fr/ec2/instance-types/t3/#Product_Details
+    "amd64" = ["t3.xlarge", "t3a.xlarge", "t2.xlarge", "m6a.xlarge"]
+    # 4 vCPU ARM64 (Gravitnb)/ 16 GB / $0.1344 - https://aws.amazon.com/fr/ec2/instance-types/t4/#Product_Details
+    "arm64" = ["t4g.xlarge", "m7g.xlarge"]
   }
   windows_winrm_user = {
     "azure-arm"  = "packer"

--- a/sources.pkr.hcl
+++ b/sources.pkr.hcl
@@ -39,7 +39,9 @@ source "azure-arm" "base" {
   managed_image_resource_group_name = local.azure_destination_resource_group
 
   vm_size = local.azure_vm_size
-  spot    = true
+  spot {
+    eviction_policy = "Delete"
+  }
 
   # Resource group where to create the VM resources (required to scope permissions into this resource group)
   build_resource_group_name = "${var.build_type}-packer-builds"

--- a/sources.pkr.hcl
+++ b/sources.pkr.hcl
@@ -2,7 +2,7 @@
 source "amazon-ebs" "base" {
   ami_name            = "${local.image_name}-${var.architecture}-${local.now_unix_timestamp}"
   spot_instance_types = local.aws_spot_instance_types[var.architecture]
-
+  spot_price          = "auto"
   # Define custom rootfs for build to avoid later filesystem extension during agent startups
   launch_block_device_mappings {
     delete_on_termination = true

--- a/sources.pkr.hcl
+++ b/sources.pkr.hcl
@@ -1,7 +1,7 @@
 # This source defines all the common settings for any AWS AMI (whatever Operating System)
 source "amazon-ebs" "base" {
-  ami_name      = "${local.image_name}-${var.architecture}-${local.now_unix_timestamp}"
-  instance_type = local.aws_instance_type[var.architecture]
+  ami_name            = "${local.image_name}-${var.architecture}-${local.now_unix_timestamp}"
+  spot_instance_types = local.aws_spot_instance_types[var.architecture]
 
   # Define custom rootfs for build to avoid later filesystem extension during agent startups
   launch_block_device_mappings {
@@ -37,6 +37,10 @@ source "amazon-ebs" "base" {
 source "azure-arm" "base" {
   managed_image_name                = local.image_name
   managed_image_resource_group_name = local.azure_destination_resource_group
+
+  vm_size = local.azure_vm_size
+  spot    = true
+
   # Resource group where to create the VM resources (required to scope permissions into this resource group)
   build_resource_group_name = "${var.build_type}-packer-builds"
 


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/3502 and https://github.com/jenkins-infra/helpdesk/issues/3485, cloud cost control is important for us.

The goal of this PR is to ensure that packer VM used to build VM templates are always using Spot prices on both AWS EC2 and Azure.