### PR TITLE
fix(windows) ensure NugetPackage Provider is present

### DIFF
--- a/provisioning/windows-provision.ps1
+++ b/provisioning/windows-provision.ps1
@@ -79,6 +79,9 @@ New-NetFirewallRule -Name sshd -DisplayName 'OpenSSH Server (sshd)' -Enabled Tru
 $baseDir = 'C:\tools'
 New-Item -ItemType Directory -Path $baseDir -Force | Out-Null
 
+# Ensure NuGet package provider is initialized (non-interactively)
+Get-PackageProvider NuGet -ForceBootstrap
+
 ## List of tools to use
 $downloads = [ordered]@{
     'jdk11' = @{


### PR DESCRIPTION
Related to https://github.com/jenkinsci/docker-agent/pull/399

This PR fixes the issue by ensuring Nuget is properly installed in *non-interactive*.
It makes this dependency explicit.

This was caused by #571 which removed the Docker installation through the `Msft` provider which was installing Nuget as a dependency.
The new Docker CE installation method does not: that's why `Nuget` is absent since the `1.1.0` image.