### PR TITLE
fix(imagename): add the cpu architecture to the name

### DIFF
--- a/build-jenkins-agent-ubuntu.pkr.hcl
+++ b/build-jenkins-agent-ubuntu.pkr.hcl
@@ -55,7 +55,7 @@ build {
 
   post-processor "docker-tag" {
     only       = ["docker.ubuntu"]
-    repository = "${var.docker_namespace}/${local.image_name}"
+    repository = "${var.docker_namespace}/${local.docker_image_name}"
     tags       = [var.image_version, "latest"]
   }
 }

--- a/locals.pkr.hcl
+++ b/locals.pkr.hcl
@@ -2,7 +2,8 @@ locals {
   now_unix_timestamp    = formatdate("YYYYMMDDhhmmss", timestamp())
   agent                 = format("%s-%s", var.agent_os_type, var.agent_os_version)
   agent_os_version_safe = replace(var.agent_os_version, ".", "_")
-  image_name            = format("jenkins-agent-%s-%s", var.agent_os_type, var.agent_os_version)
+  docker_image_name     = format("jenkins-agent-%s-%s", var.agent_os_type, var.agent_os_version)
+  image_name            = format("jenkins-agent-%s-%s-%s", var.agent_os_type, var.agent_os_version, var.architecture)
   aws_spot_instance_types = {
     # 4 vCPU x86 / 16 GB / $0.1504 - https://aws.amazon.com/fr/ec2/instance-types/t3/#Product_Details
     "amd64" = ["t3.xlarge", "t3a.xlarge", "t2.xlarge", "m6a.xlarge"]

--- a/locals.pkr.hcl
+++ b/locals.pkr.hcl
@@ -3,7 +3,8 @@ locals {
   agent                 = format("%s-%s", var.agent_os_type, var.agent_os_version)
   agent_os_version_safe = replace(var.agent_os_version, ".", "_")
   docker_image_name     = format("jenkins-agent-%s-%s", var.agent_os_type, var.agent_os_version)
-  image_name            = format("jenkins-agent-%s-%s-%s", var.agent_os_type, var.agent_os_version, var.architecture)
+  amazon_image_name     = format("jenkins-agent-%s-%s", var.agent_os_type, var.agent_os_version)
+  azure_image_name      = format("jenkins-agent-%s-%s-%s", var.agent_os_type, var.agent_os_version, var.architecture)
   aws_spot_instance_types = {
     # 4 vCPU x86 / 16 GB / $0.1504 - https://aws.amazon.com/fr/ec2/instance-types/t3/#Product_Details
     "amd64" = ["t3.xlarge", "t3a.xlarge", "t2.xlarge", "m6a.xlarge"]

--- a/sources.pkr.hcl
+++ b/sources.pkr.hcl
@@ -1,6 +1,6 @@
 # This source defines all the common settings for any AWS AMI (whatever Operating System)
 source "amazon-ebs" "base" {
-  ami_name            = "${local.image_name}-${local.now_unix_timestamp}"
+  ami_name            = "${local.amazon_image_name}-${var.architecture}-${local.now_unix_timestamp}"
   spot_instance_types = local.aws_spot_instance_types[var.architecture]
   spot_price          = "auto"
   # Define custom rootfs for build to avoid later filesystem extension during agent startups
@@ -25,7 +25,7 @@ source "amazon-ebs" "base" {
   # To improve audit and garbage collecting, we provide tags
   tags = {
     imageplatform = var.architecture
-    imagetype     = local.image_name
+    imagetype     = local.amazon_image_name
     timestamp     = local.now_unix_timestamp
     version       = var.image_version
     scm_ref       = var.scm_ref
@@ -35,7 +35,7 @@ source "amazon-ebs" "base" {
 
 # This source defines all the common settings for any Azure image (whatever Operating System)
 source "azure-arm" "base" {
-  managed_image_name                = "${local.image_name}-${local.now_unix_timestamp}"
+  managed_image_name                = "${local.azure_image_name}-${local.now_unix_timestamp}"
   managed_image_resource_group_name = local.azure_destination_resource_group
 
   vm_size = local.azure_vm_size[var.architecture]
@@ -56,7 +56,7 @@ source "azure-arm" "base" {
     subscription        = var.azure_subscription_id
     resource_group      = local.azure_destination_resource_group
     gallery_name        = "${var.build_type}_packer_images"
-    image_name          = "${local.image_name}"
+    image_name          = "${local.azure_image_name}"
     image_version       = var.image_version
     replication_regions = lookup(local.azure_galleries, "${var.build_type}_packer_images", [])
   }
@@ -64,7 +64,7 @@ source "azure-arm" "base" {
   # To improve audit and garbage collecting, we provide tags
   azure_tags = {
     imageplatform = var.architecture
-    imagetype     = local.image_name
+    imagetype     = local.azure_image_name
     timestamp     = local.now_unix_timestamp
     version       = var.image_version
     scm_ref       = var.scm_ref

--- a/sources.pkr.hcl
+++ b/sources.pkr.hcl
@@ -1,6 +1,6 @@
 # This source defines all the common settings for any AWS AMI (whatever Operating System)
 source "amazon-ebs" "base" {
-  ami_name            = "${local.image_name}-${var.architecture}-${local.now_unix_timestamp}"
+  ami_name            = "${local.image_name}-${local.now_unix_timestamp}"
   spot_instance_types = local.aws_spot_instance_types[var.architecture]
   spot_price          = "auto"
   # Define custom rootfs for build to avoid later filesystem extension during agent startups
@@ -35,7 +35,7 @@ source "amazon-ebs" "base" {
 
 # This source defines all the common settings for any Azure image (whatever Operating System)
 source "azure-arm" "base" {
-  managed_image_name                = local.image_name
+  managed_image_name                = "${local.image_name}-${local.now_unix_timestamp}"
   managed_image_resource_group_name = local.azure_destination_resource_group
 
   vm_size = local.azure_vm_size[var.architecture]
@@ -56,7 +56,7 @@ source "azure-arm" "base" {
     subscription        = var.azure_subscription_id
     resource_group      = local.azure_destination_resource_group
     gallery_name        = "${var.build_type}_packer_images"
-    image_name          = "${local.image_name}-${var.architecture}"
+    image_name          = "${local.image_name}"
     image_version       = var.image_version
     replication_regions = lookup(local.azure_galleries, "${var.build_type}_packer_images", [])
   }


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/3471
adding the architecture to the managed image name should solved the arm/amd problem
and adding the timestamp should help on the concurrent access on image with the same name during development