### PR TITLE
chore(cleanup Azure) parallelize the Gallery version deletion and fix shellcheck issues

### DIFF
--- a/cleanup/azure.sh
+++ b/cleanup/azure.sh
@@ -13,7 +13,7 @@ run_az_command() {
   else
     # Show command with "as it should run"
     echo "== DRY RUN "
-    echo "= Command that would be executed without dry-run:" 
+    echo "= Command that would be executed without dry-run:"
     echo "az" "$@"
   fi
 }
@@ -27,7 +27,7 @@ done
 ## When is yesterday exactly in YYYYMMDDHMMSS
 yesterday=""
 timeshift_days="1"
-if date -v-${timeshift_days}m > /dev/null 2>&1; then
+if date -v-${timeshift_days}d > /dev/null 2>&1; then
     # BSD systems (Mac OS X)
     yesterday="$(date -v-${timeshift_days}d +%Y%m%d%H%M%S)"
 else
@@ -40,7 +40,7 @@ az account show >/dev/null || \
   { echo "[ERROR] Unable to request the Azure API: the command 'az account show' failed. Please check your Azure credentials"; exit 1; }
 
 ## Remove running instances older than 24 hours
-INSTANCE_IDS="$(az group list --query '[?tags.timestamp.to_number(@)<=`'"${yesterday}"'`] | [?starts_with(name, '\''pkr-Resource-'\'')].name'| jq -r '.[]' | xargs)" 
+INSTANCE_IDS="$(az group list --query '[?tags.timestamp.to_number(@)<=`'"${yesterday}"'`] | [?starts_with(name, '\''pkr-Resource-'\'')].name'| jq -r '.[]' | xargs)"
 
 if [ -n "${INSTANCE_IDS}" ]
 then
@@ -67,37 +67,44 @@ fi
 for environment in dev staging
 do
   GALLERY_NAME="${environment}_packer_images"
-  RESOURCE_GROUP=$(echo $GALLERY_NAME | tr '_' '-' | tr '[:lower:]' '[:upper:]')
+  RESOURCE_GROUP=$(echo "${GALLERY_NAME}" | tr '_' '-' | tr '[:lower:]' '[:upper:]')
 
-  IMAGE_DEFINITION_NAMES="$(az sig image-definition list --gallery-name $GALLERY_NAME --resource-group $RESOURCE_GROUP | jq -r '.[].name' | xargs)" 
+  IMAGE_DEFINITION_NAMES="$(az sig image-definition list --gallery-name "${GALLERY_NAME}" --resource-group "${RESOURCE_GROUP}" | jq -r '.[].name' | xargs)"
 
   if [ -n "${IMAGE_DEFINITION_NAMES}" ]
   then
-    cpt="0"
     for imageDefinitionName in ${IMAGE_DEFINITION_NAMES}
     do
-      IMAGE_VERSIONS="$(az sig image-version list --gallery-image-definition $imageDefinitionName --gallery-name $GALLERY_NAME --resource-group $RESOURCE_GROUP | jq -r '.[].name' | xargs)" 
-
+      IMAGE_VERSIONS="$(az sig image-version list --gallery-image-definition "${imageDefinitionName}" --gallery-name "${GALLERY_NAME}" --resource-group "${RESOURCE_GROUP}" | jq -r '.[].name' | xargs)"
       if [ -n "${IMAGE_VERSIONS}" ]
       then
+        versions_to_delete=()
         for imageVersion in ${IMAGE_VERSIONS}
         do
-          run_az_command sig image-version delete --gallery-image-version $imageVersion --gallery-image-definition $imageDefinitionName --gallery-name $GALLERY_NAME --resource-group $RESOURCE_GROUP
-          ((cpt=cpt+1))
+          versions_to_delete+=("${imageVersion}")
         done
+        if [ -n "${versions_to_delete[*]}" ]
+        then
+          echo "== Preapring to delete the following versions of ${imageDefinitionName} in ${GALLERY_NAME}:"
+          echo "${versions_to_delete[*]}"
+          echo "======"
+          export -f run_az_command
+          parallel --halt-on-error never --no-run-if-empty \
+            run_az_command sig image-version delete \
+              --gallery-image-version {} \
+              --gallery-image-definition "${imageDefinitionName}" \
+              --gallery-name "${GALLERY_NAME}" \
+              --resource-group "${RESOURCE_GROUP}" \
+            ::: "${versions_to_delete[@]}"
+        else
+          echo "== No dangling images found to delete."
+        fi
       else
-        echo "No image version in $GALLERY_NAME/$imageDefinitionName"
+        echo "No dangling image versions found in ${GALLERY_NAME}/${imageDefinitionName}"
       fi
     done
-
-    if [ "${DRYRUN:-true}" = "false" ] || [ "${DRYRUN:-true}" = "no" ]
-    then
-      echo "== $cpt shared gallery image versions have been deleted in $GALLERY_NAME."
-    else
-      echo "==DRYRUN $cpt shared gallery image versions would have been deleted in $GALLERY_NAME."
-    fi
   else
-    echo "== No image definition in $GALLERY_NAME."
+    echo "== No image definition found in ${GALLERY_NAME}."
   fi
 done
 


### PR DESCRIPTION
Follow up of #627 : this PR optimizes the Azure Gallery version deletion (as it works but takes more than 1 hour today, hitting the timeout).

Also fixes shellcheck issues (protip: when using shell, always use double quote)