### PR TITLE
chore(azure cleanup) remove resources from the packer-builds RGs

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -121,7 +121,9 @@ pipeline {
               sh 'az account set -s "$PACKER_AZURE_SUBSCRIPTION_ID"'
               sh './cleanup/azure_gallery_images.sh 1 dev'
               sh './cleanup/azure_gallery_images.sh 7 staging'
-              sh './cleanup/azure.sh'
+              sh './cleanup/azure.sh 1 dev'
+              sh './cleanup/azure.sh 1 staging'
+              sh './cleanup/azure.sh 1 prod'
             }
           }
         }

--- a/cleanup/azure.sh
+++ b/cleanup/azure.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# Check input parameteres
+if ! [[ "${1:-1}" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: argument $1 is not a number" >&2
+  exit 1
+fi
+timeshift_day="${1}"
+build_type="${2:-dev}"
+
 set -eu -o pipefail
 
 run_az_command() {
@@ -24,42 +32,44 @@ do
   command -v "${cli}" >/dev/null || { echo "[ERROR] no '${cli}' command found."; exit 1; }
 done
 
-## When is yesterday exactly in YYYYMMDDHMMSS
-yesterday=""
-timeshift_days="1"
-if date -v-${timeshift_days}d > /dev/null 2>&1; then
+## Determine the time threshold
+creation_date_threshold=""
+if date -v-"${timeshift_day}d" > /dev/null 2>&1; then
     # BSD systems (Mac OS X)
-    yesterday="$(date -v-${timeshift_days}d +%Y%m%d%H%M%S)"
+    creation_date_threshold="$(date -v-"${timeshift_day}"d +%Y-%m-%d)"
 else
     # GNU systems (Linux)
-    yesterday="$(date --date="-${timeshift_days} days" +%Y%m%d%H%M%S)"
+    creation_date_threshold="$(date --date="-${timeshift_day} days" +%Y-%m-%d)"
 fi
 
 ## Check for Azure API reachability (is it configured?)
 az account show >/dev/null || \
   { echo "[ERROR] Unable to request the Azure API: the command 'az account show' failed. Please check your Azure credentials"; exit 1; }
 
-## Remove running instances older than 24 hours
-INSTANCE_IDS="$(az group list --query '[?tags.timestamp.to_number(@)<=`'"${yesterday}"'`] | [?starts_with(name, '\''pkr-Resource-'\'')].name'| jq -r '.[]' | xargs)"
+resource_group_name="${build_type}-packer-builds"
 
-if [ -n "${INSTANCE_IDS}" ]
+## Remove resources in the "Resource Group" older than the threshold
+found_resource_ids="$(az resource list --resource-group="${resource_group_name}" | jq -r ".[] | select(.timeCreated < (\"${creation_date_threshold}\")) | .id")"
+
+if [ -n "${found_resource_ids}" ]
 then
-  #shellcheck disable=SC2086
-  #has to run on each resource group
-  cpt="0"
-  for rg in ${INSTANCE_IDS}
+  resources_to_delete=()
+  for resource_id in ${found_resource_ids}
   do
-    run_az_command group delete --name "$rg" --yes --no-wait
-    ((cpt=cpt+1))
+    resources_to_delete+=("${resource_id}")
   done
 
-  if [ "${DRYRUN:-true}" = "false" ] || [ "${DRYRUN:-true}" = "no" ]
-  then
-    echo "== $cpt resources group have been deleted"
-  else
-    echo "==DRYRUN $cpt resources group would have been deleted"
-  fi
+  echo "== Preparing to delete the following resources:"
+  echo "${resources_to_delete[*]}"
+  echo "======"
+  export -f run_az_command
+  parallel --halt-on-error never --no-run-if-empty \
+    run_az_command resource delete \
+      --ids {} \
+      --resource-group "${resource_group_name}" \
+    ::: "${resources_to_delete[@]}"
 else
-  echo "== No dangling instance found to terminate."
+  echo "== No dangling resources found to terminate in ${resource_group_name}"
 fi
-echo "== Azure Instances Cleanup finished."
+
+echo "== Azure Packer Build Resources cleanup finished."


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3552, this PR cleans up ALL resources older than the provided threshold in days for each of the 3 RGs (including VM, vaults, disks, public IP, NIC, etc.)


Please note I chose to call the script 3 times (each RG) with the same threshold. The goal is to surface, at pipeline level, the parameters (instead of hiding it inside the script). 
It has the benefit to make the script simpler, less loops, so the execution time and logs are easier to gather.