### PR TITLE
chore(updatecli): correct script for docker-ce to avoid -1 in version number

### DIFF
--- a/updatecli/scripts/fetch-docker-ce-latest-version.sh
+++ b/updatecli/scripts/fetch-docker-ce-latest-version.sh
@@ -39,5 +39,5 @@ apt-cache policy docker-ce `# 1. Retrieve information about docker-ce from apt` 
   | grep 'Candidate' `# 2. Keep only the line about the Candidate version (latest available)` \
   | cut -f2,3 -d':' `# 3. Cut it so we only keep the version and remove title (version contains a :, hence keeping fields 2 and 3)` \
   | xargs `# 4. Trimming the result (removing spaces before and after)` \
-  | cut -d'~' -f1 | cut -d':' -f2 `# 5. Remove the ubuntu package prefix and suffix and last line fails if empty` \
+  | cut -d'-' -f1 | cut -d':' -f2 `# 5. Remove the ubuntu package prefix and suffix and last line fails if empty` \
   | { read -r x ; if [ "$x" == '(none)' ]; then exit 1; else echo "${x}"; fi }


### PR DESCRIPTION
as per the error in the condition:
`23.0.6-1`

```
HTTP/2 404 
x-amz-error-code: NoSuchKey
x-amz-error-message: The specified key does not exist.
x-amz-error-detail-key: win/static/stable/x86_64/docker-23.0.6-1.zip
```