### PR TITLE
chore(packer) bump the maximum version to 1.9.x

### DIFF
--- a/main.pkr.hcl
+++ b/main.pkr.hcl
@@ -1,5 +1,5 @@
 packer {
-  required_version = ">= 1.7.2, < 1.9.0"
+  required_version = ">= 1.7.2, < 1.10.0"
   required_plugins {
     amazon = {
       version = "1.2.6"


### PR DESCRIPTION
Since https://github.com/jenkins-infra/packer-images/pull/711, packer is using the 1.9.x line which throws the following error:

```
Error: Unsupported Packer Core version 
   on main.pkr.hcl line 2, in packer:
    2:   required_version = ">= 1.7.2, < 1.9.0"
```

We cannot use updatecli to automate this version constraint as packer version must be upgraded before trying to use it.