### PR TITLE
Revert "Bump launchable version to 1.67.1"

### DIFF
--- a/provisioning/tools-versions.yml
+++ b/provisioning/tools-versions.yml
@@ -20,7 +20,7 @@ jenkins_remoting_version: 3131.vf2b_b_798b_ce99
 jq_version: 1.6
 jxreleaseversion_version: 2.6.11
 kubectl_version: 1.23.13
-launchable_version: 1.67.1
+launchable_version: 1.67.0
 maven_version: 3.9.3
 netlifydeploy_version: 0.1.8
 nodejs_version: 18.13.0

--- a/provisioning/tools-versions.yml
+++ b/provisioning/tools-versions.yml
@@ -20,7 +20,7 @@ jenkins_remoting_version: 3131.vf2b_b_798b_ce99
 jq_version: 1.6
 jxreleaseversion_version: 2.6.11
 kubectl_version: 1.23.13
-launchable_version: 1.67.0
+launchable_version: 1.66.0
 maven_version: 3.9.3
 netlifydeploy_version: 0.1.8
 nodejs_version: 18.13.0


### PR DESCRIPTION
Reverts jenkins-infra/packer-images#743 and downgrade launchable to the last known working version (1.66).

cc @basil 