### PR TITLE
Bump `nodejs` version to 18.17.0

### DIFF
--- a/provisioning/tools-versions.yml
+++ b/provisioning/tools-versions.yml
@@ -24,7 +24,7 @@ kubectl_version: 1.23.13
 launchable_version: 1.66.0
 maven_version: 3.9.4
 netlifydeploy_version: 0.1.8
-nodejs_version: 18.13.0
+nodejs_version: 18.17.0
 openssh_authorized_keys_url: https://raw.githubusercontent.com/jenkins-infra/aws/main/ec2_agents_authorized_keys
 packer_version: 1.9.2
 python3_version: 3.11.5


### PR DESCRIPTION
as the old version break the builds on main (https://infra.ci.jenkins.io/blue/organizations/jenkins/infra-tools%2Fpacker-images/detail/main/809/pipeline/152#step-190-log-946) we need to bump the nodejs version.  manually for now but we need to updatecli it see : https://github.com/jenkins-infra/packer-images/issues/476#issuecomment-1702423195