### PR TITLE
fix(provision): clean playwright artifacts during sanity check

### DIFF
--- a/build-jenkins-agent-ubuntu.pkr.hcl
+++ b/build-jenkins-agent-ubuntu.pkr.hcl
@@ -50,7 +50,7 @@ build {
     inline = [
       "source /home/jenkins/.asdf/asdf.sh", # Required as this is a non-interactive and non-login `bash`
       "goss --version",
-      "su - jenkins -c 'goss --gossfile /tmp/goss.yaml validate --retry-timeout 5s'",
+      "goss --gossfile /tmp/goss.yaml validate --retry-timeout 5s",
     ]
   }
 

--- a/build-jenkins-agent-ubuntu.pkr.hcl
+++ b/build-jenkins-agent-ubuntu.pkr.hcl
@@ -50,7 +50,7 @@ build {
     inline = [
       "source /home/jenkins/.asdf/asdf.sh", # Required as this is a non-interactive and non-login `bash`
       "goss --version",
-      "goss --gossfile /tmp/goss.yaml validate --retry-timeout 5s",
+      "su - jenkins -c 'goss --gossfile /tmp/goss.yaml validate --retry-timeout 5s'",
     ]
   }
 

--- a/goss/goss.yaml
+++ b/goss/goss.yaml
@@ -40,7 +40,7 @@ command:
       - 18.18.2
     stderr: []
   playwright_version:
-    exec: "/home/jenkins/.asdf/shims/playwright --version"
+    exec: "su - jenkins -c '/home/jenkins/.asdf/shims/playwright --version'" # Playwright is installed as asdf shims for `jenkins` user only 
     exit-status: 0
     stdout:
       - 1.37.1

--- a/goss/goss.yaml
+++ b/goss/goss.yaml
@@ -38,6 +38,12 @@ command:
     exit-status: 0
     stdout:
       - 18.18.2
+    stderr: []
+  playwright --version:
+    exit-status: 0
+    stdout:
+      - 1.37.1
+    stderr: []
 file:
   /home/jenkins:
     exists: true

--- a/goss/goss.yaml
+++ b/goss/goss.yaml
@@ -39,7 +39,8 @@ command:
     stdout:
       - 18.18.2
     stderr: []
-  /home/jenkins/.asdf/shims/playwright --version:
+  playwright --version:
+    exec: "home/jenkins/.asdf/shims/playwright --version"
     exit-status: 0
     stdout:
       - 1.37.1

--- a/goss/goss.yaml
+++ b/goss/goss.yaml
@@ -39,7 +39,7 @@ command:
     stdout:
       - 18.18.2
     stderr: []
-  playwright --version:
+  /home/jenkins/.asdf/shims/playwright --version:
     exit-status: 0
     stdout:
       - 1.37.1

--- a/goss/goss.yaml
+++ b/goss/goss.yaml
@@ -39,8 +39,8 @@ command:
     stdout:
       - 18.18.2
     stderr: []
-  playwright --version:
-    exec: "home/jenkins/.asdf/shims/playwright --version"
+  playwright_version:
+    exec: "/home/jenkins/.asdf/shims/playwright --version"
     exit-status: 0
     stdout:
       - 1.37.1

--- a/goss/goss.yaml
+++ b/goss/goss.yaml
@@ -39,7 +39,7 @@ command:
     stdout:
       - 18.18.2
   playwright_version:
-    exec: "playwright --version'" # Playwright is installed as asdf shims for `jenkins` user only
+    exec: playwright --version
     exit-status: 0
     stdout:
       - 1.37.1

--- a/goss/goss.yaml
+++ b/goss/goss.yaml
@@ -39,7 +39,7 @@ command:
     stdout:
       - 18.18.2
   playwright_version:
-    exec: "su - jenkins -c '/home/jenkins/.asdf/shims/playwright --version'" # Playwright is installed as asdf shims for `jenkins` user only
+    exec: "playwright --version'" # Playwright is installed as asdf shims for `jenkins` user only
     exit-status: 0
     stdout:
       - 1.37.1

--- a/goss/goss.yaml
+++ b/goss/goss.yaml
@@ -38,13 +38,11 @@ command:
     exit-status: 0
     stdout:
       - 18.18.2
-    stderr: []
   playwright_version:
-    exec: "su - jenkins -c '/home/jenkins/.asdf/shims/playwright --version'" # Playwright is installed as asdf shims for `jenkins` user only 
+    exec: "su - jenkins -c '/home/jenkins/.asdf/shims/playwright --version'" # Playwright is installed as asdf shims for `jenkins` user only
     exit-status: 0
     stdout:
       - 1.37.1
-    stderr: []
 file:
   /home/jenkins:
     exists: true

--- a/provisioning/tools-versions.yml
+++ b/provisioning/tools-versions.yml
@@ -34,3 +34,4 @@ updatecli_version: 0.65.1
 vagrant_version: 2.4.0
 windows_pwsh_version: 7.3.7
 yq_version: 4.25.3
+playwright_version: 1.37.1

--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -575,15 +575,17 @@ function install_nodejs() {
 
 function install_playwright_dependencies() {
   ## The command 'npx playwright install-deps --dry-run' prints the expectd command for installing dependencies.
-  # But this commad requires `sudo` access (which the ${username} user does not have.
+  # But this command requires `sudo` access (which the ${username} user does not have).
   # Also, the `root` user does not have access to the ASDF setup.
+  # The version of installed package will be kept temporarily for sanity check reporting before getting cleaned up.
   # Finally, we want to cleanup the playwright installation (which is in a temporary directory)
   temp_dir=/tmp/playwright
   su - "${username}" -c " \
     source ${asdf_install_dir}/asdf.sh \
     && mkdir -p ${temp_dir} \
     && cd ${temp_dir} \
-    && npm install playwright@latest"
+    && npm install playwright@latest \
+    && npx playwright --version > /tmp/installed_playwright_version"
   # Don't forget to change dir and to remove any `stderr` to avoid polluting the evakuated command
   playwright_deps_install_command="$(su - "${username}" -c "\
     source ${asdf_install_dir}/asdf.sh \
@@ -603,10 +605,10 @@ function install_launchable() {
   ln -s "${launchable_venv_dir}/bin/launchable" /usr/local/bin/launchable
 }
 
-## Ensure that the VM is cleaned up
+## Ensure that the VM is cleaned up of provision artifacts
 function cleanup() {
   export HISTSIZE=0
-  rm -rf /tmp/* /var/log/*
+  rm -rf /tmp/* /var/log/* ${HOME}/.npm
   sync
 }
 
@@ -679,10 +681,8 @@ function sanity_check() {
   && zip -v \
   && echo 'npm version:' \
   && npm --version \
-  && echo 'playwright install:' \
-  && npm install playwright-test \
   && echo 'playwright version:' \
-  && npm @playwright/test --version \
+  && cat /tmp/installed_playwright_version \
   && echo 'launchable version:' \
   && launchable --version
   "
@@ -729,8 +729,8 @@ function main() {
   install_nodejs
   install_playwright_dependencies
   install_launchable
-  cleanup
 }
 
 main
 sanity_check
+cleanup

--- a/updatecli/updatecli.d/playwright.yml
+++ b/updatecli/updatecli.d/playwright.yml
@@ -40,7 +40,7 @@ targets:
     kind: yaml
     spec:
       file: "goss/goss.yaml"
-      key: command./playwright --version.stdout[0]
+      key: command.playwright_version.stdout[0]
 
 actions:
   default:

--- a/updatecli/updatecli.d/playwright.yml
+++ b/updatecli/updatecli.d/playwright.yml
@@ -1,0 +1,53 @@
+---
+name: Bump playwright version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastReleaseVersion:
+    kind: githubrelease
+    name: Get the latest playwright version
+    spec:
+      owner: "microsoft"
+      repository: "playwright"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: semver
+    transformers:
+      - trimprefix: v
+
+targets:
+  updateVersion:
+    name: "Update the playwright version in the provision-env.yml file"
+    kind: yaml
+    spec:
+      file: "provisioning/tools-versions.yml"
+      key: "playwright_version"
+    scmid: default
+  updateVersionInGoss:
+    name: "Update the playwright version in the goss test"
+    kind: yaml
+    spec:
+      file: "goss/goss.yaml"
+      key: command./playwright --version.stdout[0]
+
+actions:
+  default:
+    kind: github/pullrequest
+    title: Bump playwright version to {{ source "lastReleaseVersion" }}
+    scmid: default
+    spec:
+      labels:
+        - enhancement
+        - playwright


### PR DESCRIPTION
## What does this PR do?
Fixes #584 

## Description
Remove build artifacts accidentally introduced during `playwright`'s sanity check. The fix is backwards-compatible as it registers the installed `playwright`'s version somewhere before cleaning up all.
