### PR TITLE
feat: add trivy `0.45.1`

### DIFF
--- a/build-jenkins-agent-ubuntu.pkr.hcl
+++ b/build-jenkins-agent-ubuntu.pkr.hcl
@@ -40,6 +40,11 @@ build {
     destination = "/tmp/goss.yaml"
   }
 
+  provisioner "breakpoint" {
+    note    = "Enable this breakboint to pause before trying to run goss tests"
+    disable = true
+  }
+
   provisioner "shell" {
     inline = [
       "set -xeu",

--- a/build-jenkins-agent-ubuntu.pkr.hcl
+++ b/build-jenkins-agent-ubuntu.pkr.hcl
@@ -41,7 +41,7 @@ build {
   }
 
   provisioner "breakpoint" {
-    note    = "Enable this breakboint to pause before trying to run goss tests"
+    note    = "Enable this breakpoint to pause before trying to run goss tests"
     disable = true
   }
 

--- a/goss/goss.yaml
+++ b/goss/goss.yaml
@@ -24,6 +24,11 @@ command:
     stdout:
       - 21-beta
     stderr: []
+  trivy:
+    exec: /usr/local/bin/trivy --version
+    exit-status: 0
+    stdout:
+      - 0.45.1
 file:
   /home/jenkins:
     exists: true

--- a/provisioning/tools-versions.yml
+++ b/provisioning/tools-versions.yml
@@ -31,6 +31,7 @@ python3_version: 3.11.5
 ruby_version: 2.6.10
 terraform_version: 1.5.7
 tfsec_version: 1.28.1
+trivy_version: 0.45.1
 updatecli_version: 0.61.0
 vagrant_version: 2.3.7
 windows_pwsh_version: 7.3.7

--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -558,8 +558,15 @@ function install_trivy() {
     trivy_arch="ARM64"
   fi
 
-  curl --silent --location --show-error "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-${trivy_arch}.tar.gz" --output /usr/local/bin/trivy
-  chmod a+rx /usr/local/bin/trivy
+  downloaded_archive=/tmp/trivy.tgz
+
+  curl --silent --location --show-error --output "${downloaded_archive}" \
+    "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-${trivy_arch}.tar.gz"
+
+  # Only extract the binary
+  tar --extract --gunzip --file="${downloaded_archive}" --directory=/usr/local/bin trivy
+
+  rm -rf /tmp/trivy*
 }
 
 ## Install Nodejs with asdf

--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -545,7 +545,21 @@ function install_tfsec() {
   apt-get install --yes --no-install-recommends curl # Should already be there but this function should be autonomous
 
   curl --silent --location --show-error "https://github.com/aquasecurity/tfsec/releases/download/v${TFSEC_VERSION}/tfsec-linux-${ARCHITECTURE}" --output /usr/local/bin/tfsec
-  chmod +rx /usr/local/bin/tfsec
+  chmod a+rx /usr/local/bin/tfsec
+}
+
+function install_trivy() {
+  apt-get update --quiet
+  apt-get install --yes --no-install-recommends curl # Should already be there but this function should be autonomous
+
+  trivy_arch="64bit"
+  if test "${ARCHITECTURE}" == "arm64"
+  then
+    trivy_arch="ARM64"
+  fi
+
+  curl --silent --location --show-error "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-${trivy_arch}.tar.gz" --output /usr/local/bin/trivy
+  chmod a+rx /usr/local/bin/trivy
 }
 
 ## Install Nodejs with asdf
@@ -717,6 +731,7 @@ function main() {
   install_terraform
   install_kubectl
   install_tfsec
+  install_trivy
   install_nodejs
   install_playwright_dependencies
   install_launchable

--- a/provisioning/windows-provision.ps1
+++ b/provisioning/windows-provision.ps1
@@ -330,6 +330,7 @@ $downloads = [ordered]@{
             & "choco.exe" install awscli --yes --no-progress --limit-output --fail-on-error-output --version "${env:AWSCLI_VERSION}";
             & "choco.exe" install datadog-agent --yes --no-progress --limit-output --fail-on-error-output;
             & "choco.exe" install vcredist2015 --yes --no-progress --limit-output --fail-on-error-output;
+            & "choco.exe" install trivy --yes --no-progress --limit-output --fail-on-error-output --version "${env:TRIVY_VERSION}";
             # Installation of python3 for Launchable
             & "choco.exe" install python3 --yes --no-progress --limit-output --fail-on-error-output --version "${env:PYTHON3_VERSION}";
             # Installation of Launchable globally (no other python tool)

--- a/updatecli/updatecli.d/trivy.yaml
+++ b/updatecli/updatecli.d/trivy.yaml
@@ -1,0 +1,63 @@
+---
+name: Bump the `trivy` CLI version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastReleaseVersion:
+    kind: githubrelease
+    name: Get the latest `trivy` CLI version
+    spec:
+      owner: aquasecurity
+      repository: trivy
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: semver
+    transformers:
+      - trimprefix: v
+
+conditions:
+  checkForChocolateyPackage:
+    kind: shell
+    disablesourceinput: true # Do not pass source as argument to the command line
+    spec:
+      command: curl https://community.chocolatey.org/packages/trivy/{{ source "lastReleaseVersion" }} --silent --show-error --location --fail --output /dev/null
+
+targets:
+  updateVersion:
+    name: Update the `trivy` CLI version in the provision-env.yml file
+    sourceid: lastReleaseVersion
+    kind: yaml
+    spec:
+      file: provisioning/tools-versions.yml
+      key: $.trivy_version
+    scmid: default
+  updateTest:
+    name: Update the `trivy` CLI version in the test harness
+    sourceid: lastReleaseVersion
+    kind: yaml
+    spec:
+      file: goss/goss.yaml
+      key: $.command.trivy.stdout[0]
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump the `trivy` CLI version to {{ source "lastReleaseVersion" }}
+    spec:
+      labels:
+        - enhancement
+        - trivy


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3753


- Installed on both Linux arm64 + x86_64 (binary) and Windows (chocolatey)
- Tested with `goss` instead of the shell (to start migrating sanity checks to goss)
- Added an updatecli manifest to track its version (tested locally and works, but the checks will fail here)
  - Note that goss is also updated by the manifest