### PR TITLE
tests(windows) Use `goss` for sanity checks for JDKs and trivy

### DIFF
--- a/build-jenkins-agent-windows.pkr.hcl
+++ b/build-jenkins-agent-windows.pkr.hcl
@@ -67,6 +67,22 @@ build {
   provisioner "windows-restart" {
     max_retries = 3
   }
+  provisioner "file" {
+    source      = "./goss/goss-windows.yaml"
+    destination  = "C:/goss-windows.yaml"
+  }
+  provisioner "breakpoint" {
+    note    = "Enable this breakpoint to pause before trying to run goss tests"
+    disable = true
+  }
+  provisioner "powershell" {
+    inline = [
+      "$ErrorActionPreference = 'Stop'",
+      "goss --version",
+      "goss --use-alpha=1 --gossfile C:/goss-windows.yaml validate --retry-timeout 5s",
+      "Remove-Item -Force C:/goss-windows.yaml",
+    ]
+  }
   # This provisioner must be the last for Azure builds, after reboots
   provisioner "powershell" {
     only              = ["azure-arm.windows"]

--- a/goss/goss-windows.yaml
+++ b/goss/goss-windows.yaml
@@ -1,0 +1,41 @@
+command:
+  default_java:
+    exec: java --version
+    exit-status: 0
+    stdout:
+      - "11.0.20.1+1"
+  jdk8:
+    exec: C:\tools\jdk-8\bin\java.exe -version
+    exit-status: 0
+    stderr:
+      - 1.8.0_382
+  jdk11:
+    exec: C:\tools\jdk-11\bin\java.exe --version
+    exit-status: 0
+    stdout:
+      - 11.0.20.1+1
+  jdk17:
+    exec: C:\tools\jdk-17\bin\java.exe --version
+    exit-status: 0
+    stdout:
+      - 17.0.8.1+1
+  jdk21:
+    exec: C:\tools\jdk-21\bin\java.exe --version
+    exit-status: 0
+    stdout:
+      - 21+35
+  trivy:
+    exec: trivy --version
+    exit-status: 0
+    stdout:
+      - 0.46.0
+  maven:
+    exec: mvn --version
+    exit-status: 0
+    stdout:
+      - 3.9.5
+  git:
+    exec: git --version
+    exit-status: 0
+    stdout:
+      - 0.46.0

--- a/goss/goss-windows.yaml
+++ b/goss/goss-windows.yaml
@@ -3,7 +3,7 @@ command:
     exec: java --version
     exit-status: 0
     stdout:
-      - "11.0.20.1+1"
+      - 11.0.21+9
   jdk8:
     exec: C:\tools\jdk-8\bin\java.exe -version
     exit-status: 0
@@ -13,7 +13,7 @@ command:
     exec: C:\tools\jdk-11\bin\java.exe --version
     exit-status: 0
     stdout:
-      - 11.0.20.1+1
+      - 11.0.21+9
   jdk17:
     exec: C:\tools\jdk-17\bin\java.exe --version
     exit-status: 0
@@ -26,16 +26,6 @@ command:
       - 21+35
   trivy:
     exec: trivy --version
-    exit-status: 0
-    stdout:
-      - 0.46.0
-  maven:
-    exec: mvn --version
-    exit-status: 0
-    stdout:
-      - 3.9.5
-  git:
-    exec: git --version
     exit-status: 0
     stdout:
       - 0.46.0

--- a/provisioning/windows-provision.ps1
+++ b/provisioning/windows-provision.ps1
@@ -92,10 +92,6 @@ $downloads = [ordered]@{
             & Move-Item -Path "$baseDir\jdk-11*" -Destination "$baseDir\jdk-11"
         };
         'cleanupLocal' = 'true';
-        # folder included here since it's not in the PATH
-        'sanityCheck'= {
-            & "$baseDir\jdk-11\bin\java.exe" -version;
-        }
     };
     'jdk17' = @{
         'url' = 'https://github.com/adoptium/temurin17-binaries/releases/download/jdk-{0}/OpenJDK17U-jdk_x64_windows_hotspot_{1}.zip' -f [System.Web.HTTPUtility]::UrlEncode($env:JDK17_VERSION),$env:JDK17_VERSION.Replace('+', '_');
@@ -105,10 +101,6 @@ $downloads = [ordered]@{
             & Move-Item -Path "$baseDir\jdk-17*" -Destination "$baseDir\jdk-17"
         };
         'cleanupLocal' = 'true';
-        # folder included here since it's not in the PATH
-        'sanityCheck'= {
-            & "$baseDir\jdk-17\bin\java.exe" -version;
-        }
     };
     'jdk21' = @{
         'url' = 'https://github.com/adoptium/temurin21-binaries/releases/download/jdk-{0}/OpenJDK21U-jdk_x64_windows_hotspot_{1}.zip' -f [System.Web.HTTPUtility]::UrlEncode($env:JDK21_VERSION),$env:JDK21_VERSION.Replace('+', '_');
@@ -118,10 +110,6 @@ $downloads = [ordered]@{
             & Move-Item -Path "$baseDir\jdk-21*" -Destination "$baseDir\jdk-21"
         };
         'cleanupLocal' = 'true';
-        # folder included here since it's not in the PATH
-        'sanityCheck'= {
-            & "$baseDir\jdk-21\bin\java.exe" -version;
-        }
     };
     'jdk8' = @{
         'url' = 'https://github.com/adoptium/temurin8-binaries/releases/download/jdk{0}/OpenJDK8U-jdk_x64_windows_hotspot_{1}.zip' -f $env:JDK8_VERSION,$env:JDK8_VERSION.Replace('-', '');
@@ -131,10 +119,6 @@ $downloads = [ordered]@{
             & Move-Item -Path "$baseDir\jdk8*" -Destination "$baseDir\jdk-8"
         };
         'cleanupLocal' = 'true';
-        # folder included here since it's not in the PATH
-        'sanityCheck'= {
-            & "$baseDir\jdk-8\bin\java.exe" -version;
-        }
     }
     'maven' = @{
         'url' = 'https://archive.apache.org/dist/maven/maven-3/{0}/binaries/apache-maven-{0}-bin.zip' -f $env:MAVEN_VERSION;
@@ -145,9 +129,6 @@ $downloads = [ordered]@{
             'MAVEN_HOME' = '{0}\apache-maven-{1}' -f $baseDir,$env:MAVEN_VERSION;
         };
         'cleanupLocal' = 'true';
-        'sanityCheck'= {
-            & "mvn.cmd" -v;
-        }
     };
     'git' = @{
         'url' = 'https://github.com/git-for-windows/git/releases/download/v{0}.windows.1/MinGit-{0}-64-bit.zip' -f $env:GIT_WINDOWS_VERSION;
@@ -160,9 +141,6 @@ $downloads = [ordered]@{
         # git cmd and gnu tools included with git as paths
         'path' = "$baseDir\git\cmd;$baseDir\git\usr\bin";
         'cleanupLocal' = 'true';
-        'sanityCheck'= {
-            & "git.exe" --version;
-        }
     };
     'gitlfs' = @{
         'url' = 'https://github.com/git-lfs/git-lfs/releases/download/v{0}/git-lfs-windows-amd64-v{0}.zip' -f $env:GIT_LFS_VERSION;
@@ -284,6 +262,13 @@ $downloads = [ordered]@{
         'local' = "$baseDir\kubectl.exe"
         'sanityCheck'= {
             & kubectl.exe version --client;
+        }
+    };
+    'goss' = @{
+        'url' = 'https://github.com/goss-org/goss/releases/download/v{0}/goss-windows-amd64.exe'  -f $env:GOSS_VERSION;
+        'local' = "$baseDir\goss.exe"
+        'sanityCheck'= {
+            & goss.exe version;
         }
     };
     'chocolatey-and-packages' = @{


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3763

This PR introduces the following changes:

- Install `goss` on the Windows templates
- Introduces a `goss/goss-windows.yaml` test harness only for Windows which is deleted at the end (cc @smerle33 for info, we'll want to remove linux and common test harness when we will refactor)
- Add a "breakpoint" provisionner on Windows to allow local debug
- Move the sanity checks for all the JDK, trivy and default JDK

💡 Note: this PR does NOT add an updatecli manifest. We'll wait for the aforementioned refactor