### PR TITLE
hotfix(ubuntu) correct azure-cli installation method to support package increments

### DIFF
--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -396,11 +396,10 @@ function install_azurecli() {
   curl -sLS https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/keyrings/microsoft.gpg > /dev/null
   chmod go+r /etc/apt/keyrings/microsoft.gpg
   # Add the Azure CLI software repository
-  az_repo=$(lsb_release -cs)
-  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ ${az_repo} main" | tee /etc/apt/sources.list.d/azure-cli.list
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/azure-cli.list
   # Update repository information and install the azure-cli package
   apt-get update --quiet
-  apt-get install --yes --no-install-recommends azure-cli="${AZURECLI_VERSION}-1~${az_repo}"
+  apt-get install --yes --no-install-recommends azure-cli="${AZURECLI_VERSION}*"
 }
 
 ## Ensure that the GitHub command line (`gh`) is installed


### PR DESCRIPTION
The builds are failing since 24h due to the following error:

```
E: Version '2.53.0-1~jammy' for 'azure-cli' was not found
```

This PR ensures that we use a pattern to get the latest package increments