### PR TITLE
chore(updatecli): track the official jdk21 version instead of earlyavailable

### DIFF
--- a/updatecli/scripts/check-jdk.sh
+++ b/updatecli/scripts/check-jdk.sh
@@ -33,8 +33,10 @@ function get_jdk_download_url() {
       echo "https://github.com/adoptium/temurin19-binaries/releases/download/jdk-${jdk_version}/OpenJDK19U-jdk_${platform}_hotspot_${jdk_version//+/_}";
       return 0;;
     21*)
-      ## JDK21 URLs have an underscore ('_') instead of a plus ('+') in their archive names
-      echo "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-${jdk_version_urlencoded}/OpenJDK21U-jdk_${platform}_hotspot_ea_21-0-${jdk_build_number//-ea-beta/}";
+      # JDK version (21+35)
+      ##    https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21%2B35/OpenJDK21U-jdk_aarch64_linux_hotspot_21_35.tar.gz
+      urlEncodedJDKVersion="${jdk_version//+/%2B}"
+      echo "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-${urlEncodedJDKVersion}/OpenJDK21U-jdk_${platform}_hotspot_${jdk_version//+/_}"
       return 0;;
     *)
       echo "ERROR: unsupported JDK version (${jdk_version}).";

--- a/updatecli/updatecli.d/jdk21.yml
+++ b/updatecli/updatecli.d/jdk21.yml
@@ -12,25 +12,19 @@ scms:
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
       branch: "{{ .github.branch }}"
-  temurin21-binaries:
-    kind: "github"
-    spec:
-      user: "{{ .github.user }}"
-      email: "{{ .github.email }}"
-      owner: "adoptium"
-      repository: "temurin21-binaries"
-      token: '{{ requiredEnv .github.token }}'
-      branch: "main"
 
 sources:
   lastReleaseVersion:
-    kind: gittag
+    kind: githubrelease
     name: Get the latest Adoptium JDK21 version
-    scmid: temurin21-binaries
     spec:
+      owner: "adoptium"
+      repository: "temurin21-binaries"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
       versionfilter:
         kind: regex
-        pattern: ".*-ea-.*"
+        pattern: "^jdk-21.(\\d*).(\\d*).(\\d*)+(\\d*)$"
     transformers:
       - trimprefix: "jdk-"
 


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/3783