### PR TITLE
fix(windows) bump pwsh back to `7.3.7`

### DIFF
--- a/provisioning/tools-versions.yml
+++ b/provisioning/tools-versions.yml
@@ -32,5 +32,5 @@ terraform_version: 1.6.1
 trivy_version: 0.46.0
 updatecli_version: 0.64.0
 vagrant_version: 2.4.0
-windows_pwsh_version: 7.3.8
+windows_pwsh_version: 7.3.7
 yq_version: 4.25.3


### PR DESCRIPTION
Reverts https://github.com/jenkins-infra/packer-images/pull/838 which failed with the following error:

```text
09:13:59  [0;32m2023-10-17T07:13:58Z:     azure-arm.windows: pwsh not installed. The package was not found with the source(s) listed.[0m
09:13:59  [0;32m2023-10-17T07:13:58Z:     azure-arm.windows:  Source(s): 'https://community.chocolatey.org/api/v2/'[0m
09:13:59  [0;32m2023-10-17T07:13:58Z:     azure-arm.windows:  NOTE: When you specify explicit sources, it overrides default sources.[0m
09:13:59  [0;32m2023-10-17T07:13:58Z:     azure-arm.windows: If the package version is a prerelease and you didn't specify `--pre`,[0m
09:13:59  [0;32m2023-10-17T07:13:58Z:     azure-arm.windows:  the package may not be found.[0m
09:13:59  [0;32m2023-10-17T07:13:58Z:     azure-arm.windows: Version was specified as '7.3.8'. It is possible that version[0m
09:13:59  [0;32m2023-10-17T07:13:58Z:     azure-arm.windows:  does not exist for 'pwsh' at the source specified.[0m
09:13:59  [0;32m2023-10-17T07:13:58Z:     azure-arm.windows: Please see https://docs.chocolatey.org/en-us/troubleshooting for more[0m
09:13:59  [0;32m2023-10-17T07:13:58Z:     azure-arm.windows:  assistance.[0m
```