### PR TITLE
feat: Bump JDK21 to Temurin 21+35 LTS version

### DIFF
--- a/goss/goss.yaml
+++ b/goss/goss.yaml
@@ -18,7 +18,7 @@ command:
     exec: /opt/jdk-21/bin/java --version
     exit-status: 0
     stdout:
-      - 21-beta
+      - 21+35
   trivy:
     exec: trivy --version
     exit-status: 0

--- a/provisioning/tools-versions.yml
+++ b/provisioning/tools-versions.yml
@@ -14,7 +14,7 @@ goss_version: 0.4.2
 hadolint_version: 2.12.0
 jdk11_version: 11.0.21+9
 jdk17_version: 17.0.8.1+1
-jdk21_version: 21+35-ea-beta
+jdk21_version: 21+35
 jdk8_version: 8u382-b05
 jenkins_remoting_version: 3174.v2c9e67f8f9df
 jq_version: 1.6

--- a/provisioning/windows-provision.ps1
+++ b/provisioning/windows-provision.ps1
@@ -111,7 +111,7 @@ $downloads = [ordered]@{
         }
     };
     'jdk21' = @{
-        'url' = 'https://github.com/adoptium/temurin21-binaries/releases/download/jdk-{0}/OpenJDK21U-jdk_x64_windows_hotspot_ea_21-0-{1}.zip' -f [System.Web.HTTPUtility]::UrlEncode($env:JDK21_VERSION),$env:JDK21_VERSION.Split('[+-]')[1];
+        'url' = 'https://github.com/adoptium/temurin21-binaries/releases/download/jdk-{0}/OpenJDK21U-jdk_x64_windows_hotspot_{1}.zip' -f [System.Web.HTTPUtility]::UrlEncode($env:JDK21_VERSION),$env:JDK21_VERSION.Replace('+', '_');
         'local' = "$baseDir\temurin21.zip";
         'expandTo' = $baseDir;
         'postExpand' = {


### PR DESCRIPTION
- Fixup of https://github.com/jenkins-infra/packer-images/pull/839 as the download URLs in the provisioning script were not upgraded
- Closes #848 (supersedes)
- Goss is also updated 