### PR TITLE
tests: fix failing NPM check by replacing it with a NodeJS check instead

### DIFF
--- a/goss/goss.yaml
+++ b/goss/goss.yaml
@@ -29,6 +29,10 @@ command:
     exit-status: 0
     stdout:
       - v0.13.1
+  # Only check for execution, do not check for version as it is always "latest available" which changes over time
+  npm:
+    exec: npm version
+    exit-status: 0
   nodejs:
     exec: node --version
     exit-status: 0

--- a/goss/goss.yaml
+++ b/goss/goss.yaml
@@ -29,11 +29,11 @@ command:
     exit-status: 0
     stdout:
       - v0.13.1
-  npm:
-    exec: npm version
+  nodejs:
+    exec: node --version
     exit-status: 0
     stdout:
-      - "npm: '10.2.0'"
+      - 18.17.0
 file:
   /home/jenkins:
     exists: true


### PR DESCRIPTION
Fixup of https://github.com/jenkins-infra/packer-images/pull/836

We started to check for the NPM version but it failed since a few days.

- Today: Goss checks that NPM version is `10.2.0` since https://github.com/jenkins-infra/packer-images/pull/836/files#diff-9857eb30c03fe9a9f3468d7e4674aa42c75beb888b63eab5615d67fb539147e4R36
- But: during the provisioning steps (before goss) we are upgrading NPM to the latest version available: https://github.com/jenkins-infra/packer-images/blob/e5f20e37b091b58af9068d6673da0eddf0ceb723/provisioning/ubuntu-provision.sh#L565
- Since 2 days, the latest version is different, making the goss check failing.


This PR proposes to, instead:

- Only check for NPM presence 
- But check the NodeJS installed version (as we specify it)



(edit) please note that this PR is expected to:

- Fix the failing builds on the `main` branch and tags
- Allow releasing the `1.31.1` version (as the `1.30.0` failed due to this issue)
- Unblock #860 

