### PR TITLE
feat: add NodeJS to windows and track its version

### DIFF
--- a/provisioning/windows-provision.ps1
+++ b/provisioning/windows-provision.ps1
@@ -310,6 +310,7 @@ $downloads = [ordered]@{
             & "choco.exe" install datadog-agent --yes --no-progress --limit-output --fail-on-error-output;
             & "choco.exe" install vcredist2015 --yes --no-progress --limit-output --fail-on-error-output;
             & "choco.exe" install trivy --yes --no-progress --limit-output --fail-on-error-output --version "${env:TRIVY_VERSION}";
+            & "choco.exe" install nodejs.install --yes --no-progress --limit-output --fail-on-error-output --version "${env:NODEJS_VERSION}";
             # Installation of python3 for Launchable
             & "choco.exe" install python3 --yes --no-progress --limit-output --fail-on-error-output --version "${env:PYTHON3_VERSION}";
             # Installation of Launchable globally (no other python tool)

--- a/updatecli/updatecli.d/nodejs.yml
+++ b/updatecli/updatecli.d/nodejs.yml
@@ -1,0 +1,61 @@
+---
+name: Bump NodeJS version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastReleaseVersion:
+    kind: githubrelease
+    name: Get the latest NodeJS version
+    spec:
+      owner: nodejs
+      repository: node
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: regex
+        pattern: v18.(\d*).(\d*)
+    transformers:
+      - trimprefix: v
+
+conditions:
+  checkForPackage:
+    kind: shell
+    disablesourceinput: true # Do not pass source as argument to the command line
+    spec:
+      command: curl --fail --silent --show-error --location --head https://nodejs.org/dist/v{{ source "lastReleaseVersion" }}/node-v{{ source "lastReleaseVersion" }}.tar.gz
+  checkForChocolateyPackage:
+    kind: shell
+    disablesourceinput: true # Do not pass source as argument to the command line
+    spec:
+      command: curl --silent --show-error --location --fail --output /dev/null https://community.chocolatey.org/packages/nodejs.install/{{ source "lastReleaseVersion" }}
+
+targets:
+  updateVersion:
+    name: Update the NodeJS version in provisioning environment
+    sourceid: lastReleaseVersion
+    kind: yaml
+    spec:
+      file: provisioning/tools-versions.yml
+      key: nodejs_version
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    title: Bump NodeJS version to {{ source "lastReleaseVersion" }}
+    scmid: default
+    spec:
+      labels:
+        - enhancement
+        - nodejs


### PR DESCRIPTION
The goal of this PR is double:

- Same feature parity between Linux and Windows agents (NodeJS is worth installing on Windows for developers).
- Add a tracking of the (still) current LTS for NodeJS => this should propose an upgrade to latest 18.x with less download errors