### PR TITLE
chore(updatecli) fix manifests when they need to updated both GOSS test harnesses

### DIFF
--- a/updatecli/updatecli.d/jdk11.yml
+++ b/updatecli/updatecli.d/jdk11.yml
@@ -35,6 +35,8 @@ conditions:
     kind: shell
     spec:
       command: bash ./updatecli/scripts/check-jdk.sh # source input value passed as argument
+      environments:
+        - name: PATH
 
 targets:
   updateJDK11Version:
@@ -48,8 +50,20 @@ targets:
     name: Update the JDK11 version in the goss test
     kind: yaml
     spec:
-      file: "goss/goss.yaml"
+      files:
+        - goss/goss.yaml
+        - goss/goss-windows.yaml
       key: $.command.jdk11.stdout[0]
+    scmid: default
+  updateDefaultJDKVersionInGoss:
+    name: Update the default Java version in the goss tests
+    kind: yaml
+    spec:
+      files:
+        # TODO: add 'default_java' in linux tests harness
+        # - goss/goss.yaml
+        - goss/goss-windows.yaml
+      key: $.command.default_java.stdout[0]
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/jdk17.yml
+++ b/updatecli/updatecli.d/jdk17.yml
@@ -35,6 +35,9 @@ conditions:
     kind: shell
     spec:
       command: bash ./updatecli/scripts/check-jdk.sh # source input value passed as argument
+      environments:
+        - name: PATH
+
 targets:
   updateJDK17Version:
     name: Update the JDK17 version in the Packer default values
@@ -47,7 +50,9 @@ targets:
     name: Update the JDK17 version in the goss test
     kind: yaml
     spec:
-      file: "goss/goss.yaml"
+      files:
+        - goss/goss.yaml
+        - goss/goss-windows.yaml
       key: $.command.jdk17.stdout[0]
     scmid: default
 

--- a/updatecli/updatecli.d/jdk21.yml
+++ b/updatecli/updatecli.d/jdk21.yml
@@ -44,6 +44,15 @@ targets:
       file: "provisioning/tools-versions.yml"
       key: "$.jdk21_version"
     scmid: default
+  updateJDK21VersionInGoss:
+    name: Update the JDK21 version in the goss test
+    kind: yaml
+    spec:
+      files:
+        - goss/goss.yaml
+        - goss/goss-windows.yaml
+      key: $.command.jdk21.stdout[0]
+    scmid: default
 
 actions:
   default:

--- a/updatecli/updatecli.d/jdk8.yml
+++ b/updatecli/updatecli.d/jdk8.yml
@@ -34,6 +34,8 @@ conditions:
     kind: shell
     spec:
       command: bash ./updatecli/scripts/check-jdk.sh # source input value passed as argument
+      environments:
+        - name: PATH
 
 targets:
   updateJDK8Version:
@@ -52,7 +54,9 @@ targets:
           captureindex: 1
       - addprefix: '1.8.0_'
     spec:
-      file: "goss/goss.yaml"
+      files:
+        - goss/goss.yaml
+        - goss/goss-windows.yaml
       key: $.command.jdk8.stderr[0]
     scmid: default
 

--- a/updatecli/updatecli.d/playwright.yml
+++ b/updatecli/updatecli.d/playwright.yml
@@ -32,15 +32,16 @@ targets:
     name: "Update the playwright version in the provision-env.yml file"
     kind: yaml
     spec:
-      file: "provisioning/tools-versions.yml"
-      key: "playwright_version"
+      file: provisioning/tools-versions.yml
+      key: $.playwright_version
     scmid: default
   updateVersionInGoss:
     name: "Update the playwright version in the goss test"
     kind: yaml
     spec:
-      file: "goss/goss.yaml"
-      key: command.playwright_version.stdout[0]
+      file: goss/goss.yaml
+      key: $.command.playwright_version.stdout[0]
+    scmid: default
 
 actions:
   default:

--- a/updatecli/updatecli.d/trivy.yaml
+++ b/updatecli/updatecli.d/trivy.yaml
@@ -33,6 +33,8 @@ conditions:
     disablesourceinput: true # Do not pass source as argument to the command line
     spec:
       command: curl https://community.chocolatey.org/packages/trivy/{{ source "lastReleaseVersion" }} --silent --show-error --location --fail --output /dev/null
+      environments:
+        - name: PATH
 
 targets:
   updateVersion:
@@ -48,7 +50,9 @@ targets:
     sourceid: lastReleaseVersion
     kind: yaml
     spec:
-      file: goss/goss.yaml
+      files:
+        - goss/goss.yaml
+        - goss/goss-windows.yaml
       key: $.command.trivy.stdout[0]
     scmid: default
 


### PR DESCRIPTION
This PR is quick one I had in my staging area.

Closes #881 (which has its Goss test failing due to not checking the new version). A new JDK21 PR will be opened once merged here.
Closes #885 (missing `scmid` in the target preventing upgrade of goss harness).

Note: I also added a `PATH` for shell conditions when it failed to run on my machine while testing (to ensure any `asdf` or `homebrew` tools providing tools such as `jq` are being used).
Note 2: I've tested the 2 skipped manifests (trivy and JDK17) by changing the source to a kind `shell` printing the version currently in production instead of the detected one.