### PR TITLE
chore(updatecli) update manifests to also bump versions in the `goss` test harnesses

### DIFF
--- a/updatecli/updatecli.d/asdf.yml
+++ b/updatecli/updatecli.d/asdf.yml
@@ -40,7 +40,7 @@ targets:
     name: Update the ASDF version in the goss test
     kind: yaml
     spec:
-      file: "goss/goss.yaml"
+      file: "goss/goss-linux.yaml"
       key: $.command.asdf.stdout[0]
     transformers:
       - addprefix: "v"

--- a/updatecli/updatecli.d/awscli.yml
+++ b/updatecli/updatecli.d/awscli.yml
@@ -41,7 +41,14 @@ targets:
     kind: yaml
     spec:
       file: "provisioning/tools-versions.yml"
-      key: "awscli_version"
+      key: "$.awscli_version"
+    scmid: default
+  updateVersionInGoss:
+    name: Update the `aws` CLI  version in the goss test
+    kind: yaml
+    spec:
+      file: "goss/goss-linux.yaml"
+      key: $.command.awscli.stdout[0]
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/azcopy.yaml
+++ b/updatecli/updatecli.d/azcopy.yaml
@@ -1,0 +1,50 @@
+---
+name: Bump `azcopy` version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastReleaseVersion:
+    kind: shell
+    name: Get the latest `azcopy` (full) version
+    spec:
+      command: bash -c 'basename "$(dirname "$(curl https://aka.ms/downloadazcopy-v10-linux --write-out "%{redirect_url}" --output /dev/null --silent --fail --show-error)" )"'
+    transformers:
+      - trimprefix: 'release-'
+
+targets:
+  updateVersion:
+    name: "Update the `azcopy` version in the provision-env.yml file"
+    sourceid: lastReleaseVersion
+    kind: yaml
+    spec:
+      file: provisioning/tools-versions.yml
+      key: $.azcopy_version
+    scmid: default
+  updateVersionInGoss:
+    name: Update the `azcopy` version in the goss test
+    kind: yaml
+    spec:
+      file: goss/goss-linux.yaml
+      key: $.command.azcopy.stdout[0]
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    title: Bump azcopy version to {{ source "lastReleaseVersion" }}
+    scmid: default
+    spec:
+      labels:
+        - enhancement
+        - azcopy

--- a/updatecli/updatecli.d/azure-cli.yml
+++ b/updatecli/updatecli.d/azure-cli.yml
@@ -31,12 +31,19 @@ sources:
 
 targets:
   updateVersion:
-    name: "Update the azure-cli version in the provision-env.yml file"
+    name: "Update the `azure-cli` version in the provision-env.yml file"
     sourceid: lastReleaseVersion
     kind: yaml
     spec:
       file: "provisioning/tools-versions.yml"
-      key: "azurecli_version"
+      key: "$.azurecli_version"
+    scmid: default
+  updateVersionInGoss:
+    name: Update the `azure-cli` version in the goss test
+    kind: yaml
+    spec:
+      file: "goss/goss-linux.yaml"
+      key: $.command.azurecli.stdout[0]
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/compose.yml
+++ b/updatecli/updatecli.d/compose.yml
@@ -29,11 +29,18 @@ sources:
 
 targets:
   updateDockerComposeVersion:
-    name: Update the DockerCompose version in the Packer default values
+    name: Update the `DockerCompose` version in the Packer default values
     kind: yaml
     spec:
       file: "provisioning/tools-versions.yml"
       key: "compose_version"
+    scmid: default
+  updateVersionInGoss:
+    name: Update the `DockerCompose` version in the goss test
+    kind: yaml
+    spec:
+      file: "goss/goss-linux.yaml"
+      key: $.command.docker-compose.stdout[0]
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/container-structure-test.yml
+++ b/updatecli/updatecli.d/container-structure-test.yml
@@ -29,12 +29,21 @@ sources:
 
 targets:
   updateVersion:
-    name: "Update the container-structure-test version in the provision-env.yml file"
+    name: "Update the `container-structure-test` version in the provision-env.yml file"
     sourceid: lastReleaseVersion
     kind: yaml
     spec:
       file: "provisioning/tools-versions.yml"
-      key: "cst_version"
+      key: "$.cst_version"
+    scmid: default
+  updateVersionInGoss:
+    name: Update the `container-structure-test` version in the goss test
+    kind: yaml
+    spec:
+      file: "goss/goss-linux.yaml"
+      key: $.command.container-structure-test.stdout[0]
+    transformers:
+      - addprefix: "v"
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/docker-ce.yaml
+++ b/updatecli/updatecli.d/docker-ce.yaml
@@ -29,13 +29,20 @@ conditions:
 
 targets:
   updateVersion:
-    name: "Update the docker-ce version in the provision-env.yml file"
+    name: "Update the `docker-ce` version in the provision-env.yml file"
     sourceid: lastReleaseVersion
     kind: yaml
     spec:
       file: "provisioning/tools-versions.yml"
-      key: "docker_version"
+      key: "$.docker_version"
     scmid: default
+  updateVersionInGoss:
+    name: Update the `docker-ce` version in the goss test
+    kind: yaml
+    spec:
+      file: "goss/goss-linux.yaml"
+      key: $.command.docker-ce.stdout[0]
+    # scmid: default
 
 actions:
   default:

--- a/updatecli/updatecli.d/docker-ce.yaml
+++ b/updatecli/updatecli.d/docker-ce.yaml
@@ -1,5 +1,5 @@
 ---
-name: Bump docker-ce version
+name: Bump Docker CE version
 
 scms:
   default:
@@ -19,6 +19,8 @@ sources:
     kind: shell
     spec:
       command: bash ./updatecli/scripts/run-in-docker.sh ./updatecli/scripts/fetch-docker-ce-latest-version.sh
+      environments:
+        - name: PATH
 
 conditions:
   checkIfWindowsReleaseIsAvailable:
@@ -29,25 +31,25 @@ conditions:
 
 targets:
   updateVersion:
-    name: "Update the `docker-ce` version in the provision-env.yml file"
+    name: Update the Docker CE version in the provision-env.yml file
     sourceid: lastReleaseVersion
     kind: yaml
     spec:
-      file: "provisioning/tools-versions.yml"
-      key: "$.docker_version"
+      file: provisioning/tools-versions.yml
+      key: $.docker_version
     scmid: default
   updateVersionInGoss:
-    name: Update the `docker-ce` version in the goss test
+    name: Update the Docker CE version in the Linux goss test harness
     kind: yaml
     spec:
-      file: "goss/goss-linux.yaml"
+      file: goss/goss-linux.yaml
       key: $.command.docker-ce.stdout[0]
-    # scmid: default
+    scmid: default
 
 actions:
   default:
     kind: github/pullrequest
-    title: Bump docker-ce version to {{ source "lastReleaseVersion" }}
+    title: Bump Docker CE version to {{ source "lastReleaseVersion" }}
     scmid: default
     spec:
       labels:

--- a/updatecli/updatecli.d/docker-compose.yml
+++ b/updatecli/updatecli.d/docker-compose.yml
@@ -40,7 +40,7 @@ targets:
     kind: yaml
     spec:
       file: "goss/goss-linux.yaml"
-      key: $.command.docker-compose.stdout[0]
+      key: $.command.docker_compose.stdout[0]
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/github-cli.yml
+++ b/updatecli/updatecli.d/github-cli.yml
@@ -41,7 +41,7 @@ targets:
     kind: yaml
     spec:
       file: "goss/goss-linux.yaml"
-      key: $.command.github-cli.stdout[0]
+      key: $.command.gh_cli.stdout[0]
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/github-cli.yml
+++ b/updatecli/updatecli.d/github-cli.yml
@@ -29,12 +29,19 @@ sources:
 
 targets:
   updateVersion:
-    name: "Update the GitHub CLI (gh) version in the provision-env.yml file"
+    name: "Update the `GitHub CLI (gh)` version in the provision-env.yml file"
     sourceid: lastReleaseVersion
     kind: yaml
     spec:
       file: "provisioning/tools-versions.yml"
       key: "gh_version"
+    scmid: default
+  updateVersionInGoss:
+    name: Update the `GitHub CLI (gh)` version in the goss test
+    kind: yaml
+    spec:
+      file: "goss/goss-linux.yaml"
+      key: $.command.github-cli.stdout[0]
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/jdk11.yml
+++ b/updatecli/updatecli.d/jdk11.yml
@@ -51,7 +51,7 @@ targets:
     kind: yaml
     spec:
       files:
-        - goss/goss.yaml
+        - goss/goss-linux.yaml
         - goss/goss-windows.yaml
       key: $.command.jdk11.stdout[0]
     scmid: default
@@ -61,7 +61,7 @@ targets:
     spec:
       files:
         # TODO: add 'default_java' in linux tests harness
-        # - goss/goss.yaml
+        # - goss/goss-linux.yaml
         - goss/goss-windows.yaml
       key: $.command.default_java.stdout[0]
     scmid: default

--- a/updatecli/updatecli.d/jdk17.yml
+++ b/updatecli/updatecli.d/jdk17.yml
@@ -51,7 +51,7 @@ targets:
     kind: yaml
     spec:
       files:
-        - goss/goss.yaml
+        - goss/goss-linux.yaml
         - goss/goss-windows.yaml
       key: $.command.jdk17.stdout[0]
     scmid: default

--- a/updatecli/updatecli.d/jdk21.yml
+++ b/updatecli/updatecli.d/jdk21.yml
@@ -49,7 +49,7 @@ targets:
     kind: yaml
     spec:
       files:
-        - goss/goss.yaml
+        - goss/goss-linux.yaml
         - goss/goss-windows.yaml
       key: $.command.jdk21.stdout[0]
     scmid: default

--- a/updatecli/updatecli.d/jdk8.yml
+++ b/updatecli/updatecli.d/jdk8.yml
@@ -55,7 +55,7 @@ targets:
       - addprefix: '1.8.0_'
     spec:
       files:
-        - goss/goss.yaml
+        - goss/goss-linux.yaml
         - goss/goss-windows.yaml
       key: $.command.jdk8.stderr[0]
     scmid: default

--- a/updatecli/updatecli.d/nodejs.yml
+++ b/updatecli/updatecli.d/nodejs.yml
@@ -54,7 +54,7 @@ targets:
     sourceid: lastReleaseVersion
     kind: yaml
     spec:
-      file: goss/goss.yaml
+      file: goss/goss-linux.yaml
       key: $.command.nodejs.stdout[0]
     scmid: default
 

--- a/updatecli/updatecli.d/playwright.yml
+++ b/updatecli/updatecli.d/playwright.yml
@@ -39,7 +39,7 @@ targets:
     name: "Update the playwright version in the goss test"
     kind: yaml
     spec:
-      file: goss/goss.yaml
+      file: goss/goss-linux.yaml
       key: $.command.playwright_version.stdout[0]
     scmid: default
 

--- a/updatecli/updatecli.d/python3.yml
+++ b/updatecli/updatecli.d/python3.yml
@@ -19,6 +19,8 @@ sources:
     name: Get the latest python3 version
     spec:
       command: curl https://endoflife.date/api/python.json --silent --show-error | jq -r '.[0].latest'
+      environments:
+        - name: PATH
 
 conditions:
   ## Only check for chocolatey package

--- a/updatecli/updatecli.d/trivy.yaml
+++ b/updatecli/updatecli.d/trivy.yaml
@@ -51,7 +51,7 @@ targets:
     kind: yaml
     spec:
       files:
-        - goss/goss.yaml
+        - goss/goss-linux.yaml
         - goss/goss-windows.yaml
       key: $.command.trivy.stdout[0]
     scmid: default


### PR DESCRIPTION
After PR https://github.com/jenkins-infra/packer-images/pull/852 we need to update all the updatecli manifest to use the new goss file name goss-linux.yaml

(edit by @dduportal)

This PR also introduces:
- Fixes of `updatecli` after #897 
- Track `azcopy` after #898 
