### PR TITLE
feat: add `azcopy` to Linux provisioning

### DIFF
--- a/goss/goss-linux.yaml
+++ b/goss/goss-linux.yaml
@@ -52,6 +52,11 @@ command:
     exit-status: 0
     stdout:
       - 2.53.1
+  azcopy:
+    exec: azcopy --version
+    exit-status: 0
+    stdout:
+      - 10.21.0
   bundle:  # not updatecli tracked
     exec: bundle -v
     exit-status: 0

--- a/provisioning/tools-versions.yml
+++ b/provisioning/tools-versions.yml
@@ -1,5 +1,6 @@
 asdf_version: 0.13.1
 awscli_version: 2.13.32
+azcopy_version: 10.21.0-20230928
 azurecli_version: 2.53.1
 chocolatey_version: 1.4.0
 compose_version: 2.23.0

--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -407,7 +407,7 @@ function install_azurecli() {
 function install_azcopy() {
   azcopysemver="$(echo "${AZCOPY_VERSION}" | cut -d'-' -f1)"
   curl --silent --show-error --location --output /tmp/azcopy.tar.gz \
-    "https://azcopyvnext.azureedge.net/releases/release-${AZCOPY_VERSION}/azcopy_linux_${ARCHITECTURE}}_${azcopysemver}.tar.gz"
+    "https://azcopyvnext.azureedge.net/releases/release-${AZCOPY_VERSION}/azcopy_linux_${ARCHITECTURE}_${azcopysemver}.tar.gz"
   tar --extract --gunzip --file=/tmp/azcopy.tar.gz --strip-components=1 --wildcards '*/azcopy' --directory=/usr/local/bin/
   rm -rf /tmp/azcopy.tar.gz
 }

--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -405,9 +405,9 @@ function install_azurecli() {
 
 ## Ensure that azcopy is installed
 function install_azcopy() {
-  azcopysemver=$(echo "${AZCOPY_VERSION}" | cut -d'-' -f1)
+  azcopysemver="$(echo "${AZCOPY_VERSION}" | cut -d'-' -f1)"
   curl --silent --show-error --location --output /tmp/azcopy.tar.gz \
-    "https://azcopyvnext.azureedge.net/releases/release-${GH_VERSION}/azcopy_linux_${ARCHITECTURE}}_${azcopysemver}.tar.gz"
+    "https://azcopyvnext.azureedge.net/releases/release-${AZCOPY_VERSION}/azcopy_linux_${ARCHITECTURE}}_${azcopysemver}.tar.gz"
   tar --extract --gunzip --file=/tmp/azcopy.tar.gz --strip-components=1 --wildcards '*/azcopy' --directory=/usr/local/bin/
   rm -rf /tmp/azcopy.tar.gz
 }
@@ -688,6 +688,7 @@ function main() {
   install_datadog
   install_JA_requirements
   install_qemu
+  install_azcopy
   install_python
   install_docker_compose
   install_maven

--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -406,9 +406,10 @@ function install_azurecli() {
 ## Ensure that azcopy is installed
 function install_azcopy() {
   azcopysemver="$(echo "${AZCOPY_VERSION}" | cut -d'-' -f1)"
-  curl --silent --show-error --location --output /tmp/azcopy.tar.gz \
+  curl --fail --silent --show-error --location --output /tmp/azcopy.tar.gz \
     "https://azcopyvnext.azureedge.net/releases/release-${AZCOPY_VERSION}/azcopy_linux_${ARCHITECTURE}_${azcopysemver}.tar.gz"
-  tar --extract --gunzip --file=/tmp/azcopy.tar.gz --strip-components=1 --wildcards '*/azcopy' --directory=/usr/local/bin/
+  tar --extract --gunzip --directory=/usr/local/bin/ --file=/tmp/azcopy.tar.gz --strip-components=1 --wildcards '*/azcopy'
+  chmod a+x /usr/local/bin/azcopy
   rm -rf /tmp/azcopy.tar.gz
 }
 

--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -403,6 +403,15 @@ function install_azurecli() {
   apt-get install --yes --no-install-recommends azure-cli="${AZURECLI_VERSION}*"
 }
 
+## Ensure that azcopy is installed
+function install_azcopy() {
+  azcopysemver=$(echo "${AZCOPY_VERSION}" | cut -d'-' -f1)
+  curl --silent --show-error --location --output /tmp/azcopy.tar.gz \
+    "https://azcopyvnext.azureedge.net/releases/release-${GH_VERSION}/azcopy_linux_${ARCHITECTURE}}_${azcopysemver}.tar.gz"
+  tar --extract --gunzip --file=/tmp/azcopy.tar.gz --strip-components=1 --wildcards '*/azcopy' --directory=/usr/local/bin/
+  rm -rf /tmp/azcopy.tar.gz
+}
+
 ## Ensure that the GitHub command line (`gh`) is installed
 function install_gh() {
   curl --silent --show-error --location --output /tmp/gh.tar.gz \


### PR DESCRIPTION
This PR adds https://github.com/Azure/azure-storage-azcopy to Linux provisioning so we can use it in https://github.com/jenkins-infra/crawler/ job to synchronize the Update Center File Share that will be used by updates.jenkins.io.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-1807816044