### PR TITLE
chore(goss) fix azcopy version check and updatecli tracking

### DIFF
--- a/goss/goss-linux.yaml
+++ b/goss/goss-linux.yaml
@@ -18,7 +18,7 @@ command:
     exec: azcopy --version
     exit-status: 0
     stdout:
-      - 10.21.2-20231106
+      - 10.21.2
   bundle:
     exec: bundle -v
     exit-status: 0

--- a/updatecli/updatecli.d/azcopy.yaml
+++ b/updatecli/updatecli.d/azcopy.yaml
@@ -34,6 +34,10 @@ targets:
   updateVersionInGoss:
     name: Update the `azcopy` version in the goss test
     kind: yaml
+    transformers:
+      - findsubmatch:
+          pattern: '(.*)-(.*)'
+          captureindex: 1
     spec:
       file: goss/goss-linux.yaml
       key: $.command.azcopy.stdout[0]


### PR DESCRIPTION
Fixup of #900

This PR fixes the goss Linux harness to check for the semantic version (x.y.z) instead of the full version (x.y.z-<timestamp>) for `azcopy.

The updatecli manifest is updated to avoid reproducing this error (introduced in #896 when I added the `azcopy` manifest)