### PR TITLE
chore(updatecli): update to keep goss file up2date

### DIFF
--- a/goss/goss-linux.yaml
+++ b/goss/goss-linux.yaml
@@ -144,7 +144,7 @@ command:
   parallel:
     exec: parallel --version
     exit-status: 0
-  playwright_version:
+  playwright:
     exec: playwright --version
     exit-status: 0
     stdout:
@@ -153,7 +153,7 @@ command:
     exec: python3 --version
     exit-status: 0
     stdout:
-      - 3.10.12
+      - 3.12.0
   ruby:
     exec: ruby -v
     exit-status: 0
@@ -184,7 +184,7 @@ command:
     exec: vagrant -v
     exit-status: 0
     stdout:
-      - 2.2.19
+      - 2.4.0
   yq:
     exec: yq --version
     exit-status: 0

--- a/goss/goss-linux.yaml
+++ b/goss/goss-linux.yaml
@@ -152,8 +152,6 @@ command:
   python3:
     exec: python3 --version
     exit-status: 0
-    stdout:
-      - 3.12.0
   ruby:
     exec: ruby -v
     exit-status: 0

--- a/goss/goss-linux.yaml
+++ b/goss/goss-linux.yaml
@@ -183,8 +183,6 @@ command:
   vagrant:
     exec: vagrant -v
     exit-status: 0
-    stdout:
-      - 2.4.0
   yq:
     exec: yq --version
     exit-status: 0

--- a/goss/goss-linux.yaml
+++ b/goss/goss-linux.yaml
@@ -183,6 +183,8 @@ command:
   vagrant:
     exec: vagrant -v
     exit-status: 0
+    stdout:
+      - 2.2.19
   yq:
     exec: yq --version
     exit-status: 0

--- a/provisioning/tools-versions.yml
+++ b/provisioning/tools-versions.yml
@@ -1,3 +1,4 @@
+# if manually change, please update the goss file accordingly
 asdf_version: 0.13.1
 awscli_version: 2.13.35
 azcopy_version: 10.21.2-20231106

--- a/updatecli/updatecli.d/hadolint.yml
+++ b/updatecli/updatecli.d/hadolint.yml
@@ -29,12 +29,20 @@ sources:
 
 targets:
   updateVersion:
-    name: "Update the hadolint version in the provision-env.yml file"
+    name: "Update the `hadolint` version in the provision-env.yml file"
     sourceid: lastReleaseVersion
     kind: yaml
     spec:
       file: "provisioning/tools-versions.yml"
-      key: "hadolint_version"
+      key: "$.hadolint_version"
+    scmid: default
+  updateHadolintVersionInGoss:
+    name: Update the `hadolint` version in the goss test
+    kind: yaml
+    spec:
+      files:
+        - goss/goss-linux.yaml
+      key: $.command.hadolint.stdout[0]
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/jdk11.yml
+++ b/updatecli/updatecli.d/jdk11.yml
@@ -60,8 +60,7 @@ targets:
     kind: yaml
     spec:
       files:
-        # TODO: add 'default_java' in linux tests harness
-        # - goss/goss-linux.yaml
+        - goss/goss-linux.yaml
         - goss/goss-windows.yaml
       key: $.command.default_java.stdout[0]
     scmid: default

--- a/updatecli/updatecli.d/jq.yml
+++ b/updatecli/updatecli.d/jq.yml
@@ -36,7 +36,15 @@ targets:
     kind: yaml
     spec:
       file: "provisioning/tools-versions.yml"
-      key: "jq_version"
+      key: "$.jq_version"
+    scmid: default
+  updateJQVersionInGoss:
+    name: Update the `jq` version in the goss test
+    kind: yaml
+    spec:
+      files:
+        - goss/goss-linux.yaml
+      key: $.command.jq.stdout[0]
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/jx-release-version.yml
+++ b/updatecli/updatecli.d/jx-release-version.yml
@@ -29,12 +29,20 @@ sources:
 
 targets:
   updateVersion:
-    name: "Update the jx-release-version version in the provision-env.yml file"
+    name: "Update the `jx-release-version` version in the provision-env.yml file"
     sourceid: lastReleaseVersion
     kind: yaml
     spec:
       file: "provisioning/tools-versions.yml"
-      key: "jxreleaseversion_version"
+      key: "$.jxreleaseversion_version"
+    scmid: default
+  updateJxReleaseVersionInGoss:
+    name: Update the `jx-release-version` version in the goss test
+    kind: yaml
+    spec:
+      files:
+        - goss/goss-linux.yaml
+      key: $.command.jx-release-version.stdout[0]
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/launchable.yml
+++ b/updatecli/updatecli.d/launchable.yml
@@ -29,12 +29,20 @@ sources:
 
 targets:
   updateVersion:
-    name: "Update the launchable version in the provision-env.yml file"
+    name: "Update the `launchable` version in the provision-env.yml file"
     sourceid: lastReleaseVersion
     kind: yaml
     spec:
       file: "provisioning/tools-versions.yml"
-      key: "launchable_version"
+      key: "$.launchable_version"
+    scmid: default
+  updateLaunchableVersionInGoss:
+    name: Update the `launchable` version in the goss test
+    kind: yaml
+    spec:
+      files:
+        - goss/goss-linux.yaml
+      key: $.command.launchable.stdout[0]
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/maven.yml
+++ b/updatecli/updatecli.d/maven.yml
@@ -38,11 +38,19 @@ conditions:
 
 targets:
   updateMavenVersion:
-    name: Update the Maven version in the Packer default values
+    name: Update the `Maven` version in the Packer default values
     kind: yaml
     spec:
       file: "provisioning/tools-versions.yml"
-      key: "maven_version"
+      key: "$.maven_version"
+    scmid: default
+  updateMavenVersionInGoss:
+    name: Update the `Maven` version in the goss test
+    kind: yaml
+    spec:
+      files:
+        - goss/goss-linux.yaml
+      key: $.command.maven.stdout[0]
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/packer.yml
+++ b/updatecli/updatecli.d/packer.yml
@@ -37,12 +37,20 @@ conditions:
 
 targets:
   updateVersion:
-    name: "Update the packer version in the provision-env.yml file"
+    name: "Update the `packer` version in the provision-env.yml file"
     sourceid: lastReleaseVersion
     kind: yaml
     spec:
       file: "provisioning/tools-versions.yml"
-      key: "packer_version"
+      key: "$.packer_version"
+    scmid: default
+  updatePackerVersionInGoss:
+    name: Update the `packer` CLI version in the goss test
+    kind: yaml
+    spec:
+      files:
+        - goss/goss-linux.yaml
+      key: $.command.packer.stdout[0]
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/playwright.yml
+++ b/updatecli/updatecli.d/playwright.yml
@@ -40,7 +40,7 @@ targets:
     kind: yaml
     spec:
       file: goss/goss-linux.yaml
-      key: $.command.playwright_version.stdout[0]
+      key: $.command.playwright.stdout[0]
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/python3.yml
+++ b/updatecli/updatecli.d/python3.yml
@@ -37,7 +37,15 @@ targets:
     kind: yaml
     spec:
       file: "provisioning/tools-versions.yml"
-      key: "python3_version"
+      key: "$.python3_version"
+    scmid: default
+  updatePackerVersionInGoss:
+    name: Update the `python3` CLI version in the goss test
+    kind: yaml
+    spec:
+      files:
+        - goss/goss-linux.yaml
+      key: $.command.python3.stdout[0]
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/python3.yml
+++ b/updatecli/updatecli.d/python3.yml
@@ -39,14 +39,6 @@ targets:
       file: "provisioning/tools-versions.yml"
       key: "$.python3_version"
     scmid: default
-  updatePackerVersionInGoss:
-    name: Update the `python3` CLI version in the goss test
-    kind: yaml
-    spec:
-      files:
-        - goss/goss-linux.yaml
-      key: $.command.python3.stdout[0]
-    scmid: default
 
 actions:
   default:

--- a/updatecli/updatecli.d/terraform.yml
+++ b/updatecli/updatecli.d/terraform.yml
@@ -36,12 +36,19 @@ conditions:
 
 targets:
   updateVersion:
-    name: "Update the TERRAFORM version in the provisioning/tools-versions.yml file"
+    name: "Update the `TERRAFORM` version in the provisioning/tools-versions.yml file"
     sourceid: lastReleaseVersion
     kind: yaml
     spec:
       file: "provisioning/tools-versions.yml"
-      key: "terraform_version"
+      key: "$.terraform_version"
+    scmid: default
+  updateVersionInGoss:
+    name: "Update the `TERRAFORM` version in the goss test"
+    kind: yaml
+    spec:
+      file: goss/goss-linux.yaml
+      key: $.command.terraform.stdout[0]
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/updatecli.yml
+++ b/updatecli/updatecli.d/updatecli.yml
@@ -34,7 +34,14 @@ targets:
     kind: yaml
     spec:
       file: "provisioning/tools-versions.yml"
-      key: "updatecli_version"
+      key: "$.updatecli_version"
+    scmid: default
+  updateVersionInGoss:
+    name: "Update the `updatecli` version in the goss test"
+    kind: yaml
+    spec:
+      file: goss/goss-linux.yaml
+      key: $.command.updatecli.stderr[0]
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/vagrant.yml
+++ b/updatecli/updatecli.d/vagrant.yml
@@ -45,13 +45,6 @@ targets:
       file: "provisioning/tools-versions.yml"
       key: "$.vagrant_version"
     scmid: default
-  updateVersionInGoss:
-    name: "Update the `vagrant` version in the goss test"
-    kind: yaml
-    spec:
-      file: goss/goss-linux.yaml
-      key: $.command.vagrant.stdout[0]
-    scmid: default
 
 actions:
   default:

--- a/updatecli/updatecli.d/vagrant.yml
+++ b/updatecli/updatecli.d/vagrant.yml
@@ -38,12 +38,19 @@ conditions:
 
 targets:
   updateVersion:
-    name: "Update the vagrant version in the provision-env.yml file"
+    name: "Update the `vagrant` version in the provision-env.yml file"
     sourceid: lastReleaseVersion
     kind: yaml
     spec:
       file: "provisioning/tools-versions.yml"
-      key: "vagrant_version"
+      key: "$.vagrant_version"
+    scmid: default
+  updateVersionInGoss:
+    name: "Update the `vagrant` version in the goss test"
+    kind: yaml
+    spec:
+      file: goss/goss-linux.yaml
+      key: $.command.vagrant.stdout[0]
     scmid: default
 
 actions:


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/3763

following https://github.com/jenkins-infra/packer-images/pull/906
update the corresponding updatecli manifest to keep the goss file on track.