### PR TITLE
chore(updatecli, tests) fix Linux Git manifest to also update goss

### DIFF
--- a/goss/goss-linux.yaml
+++ b/goss/goss-linux.yaml
@@ -61,7 +61,7 @@ command:
     exec: git --version
     exit-status: 0
     stdout:
-      - 2.42.0
+      - 2.43.0
   git_lfs:
     exec: git-lfs --version
     exit-status: 0

--- a/updatecli/updatecli.d/git-linux.yml
+++ b/updatecli/updatecli.d/git-linux.yml
@@ -18,8 +18,8 @@ sources:
     kind: githubrelease
     name: Get the latest Git version
     spec:
-      owner: "git"
-      repository: "git"
+      owner: git
+      repository: git
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
       versionfilter:
@@ -29,11 +29,18 @@ sources:
 
 targets:
   updateGitVersion:
-    name: Update the Git version in the Packer default values
+    name: Bump Git version on Linux in the Packer default values
     kind: yaml
     spec:
-      file: "provisioning/tools-versions.yml"
-      key: "git_linux_version"
+      file: provisioning/tools-versions.yml
+      key: $.git_linux_version
+    scmid: default
+  updateVersionInGoss:
+    name: Bump Git version on Linux in the goss test
+    kind: yaml
+    spec:
+      file: goss/goss-linux.yaml
+      key: $.command.git.stdout[0]
     scmid: default
 
 actions:


### PR DESCRIPTION
- Updates the version of git in the Linux Goss test harness (fixup of #893)
- Fixes the `updatecli` manifest to update Git version in the Linux Goss test harness (fixup of #910)