### PR TITLE
Revert "Bump container-structure-test version to 1.16.1"

### DIFF
--- a/goss/goss-linux.yaml
+++ b/goss/goss-linux.yaml
@@ -30,7 +30,7 @@ command:
     exec: container-structure-test version
     exit-status: 0
     stdout:
-      - v1.16.1
+      - v1.16.0
   datadog-agent:
     exec: datadog-agent version
     exit-status: 0

--- a/provisioning/tools-versions.yml
+++ b/provisioning/tools-versions.yml
@@ -5,7 +5,7 @@ azcopy_version: 10.21.2-20231106
 azurecli_version: 2.54.0
 chocolatey_version: 1.4.0
 compose_version: 2.23.1
-cst_version: 1.16.1
+cst_version: 1.16.0
 default_jdk: 11
 docker_version: 24.0.7
 gh_version: 2.39.1


### PR DESCRIPTION
Reverts jenkins-infra/packer-images#921

Reverting as the 1.16.1 release doesn't contain any binaries.

- https://github.com/GoogleContainerTools/container-structure-test/releases/tag/v1.16.1
- https://github.com/GoogleContainerTools/container-structure-test/issues/397