### PR TITLE
hotfix(goss) bump git LFS to 3.4.1

### DIFF
--- a/goss/goss-linux.yaml
+++ b/goss/goss-linux.yaml
@@ -66,7 +66,7 @@ command:
     exec: git-lfs --version
     exit-status: 0
     stdout:
-      - 3.4.0
+      - 3.4.1
   goss:
     exec: goss --version
     exit-status: 0


### PR DESCRIPTION
Fixup of #910 (missing git lfs goss tracking in updatecli) and #944 (git LFS version tracking only updated in the provisioning file)


- This PR fixes the failing build (when git LFS version is checked by goss on Linux)
- The PR #940 ensures this problem won't happen again for Git LFS