### PR TITLE
fixup(goss): putting back exit-status: 0 which is required

### DIFF
--- a/goss/goss-linux.yaml
+++ b/goss/goss-linux.yaml
@@ -2,154 +2,198 @@
 command:
   asdf:
     exec: asdf version
+    exit-status: 0
     stdout:
       - v0.13.1
   awscli:
     exec: aws --version
+    exit-status: 0
     stdout:
       - 2.15.2
   azcopy:
     exec: azcopy --version
+    exit-status: 0
     stdout:
       - 10.21.2
   azurecli:
     exec: az --version
+    exit-status: 0
     stdout:
       - 2.55.0
   bundle:
     exec: bundle -v
+    exit-status: 0
   chromium-browser:
     exec: chromium-browser --version
+    exit-status: 0
   container-structure-test:
     exec: container-structure-test version
+    exit-status: 0
     stdout:
       - v1.16.0
   datadog-agent:
     exec: datadog-agent version
+    exit-status: 0
   default_java:
     exec: java --version
+    exit-status: 0
     stdout:
       - 11.0.21+9
   docker-ce:
     exec: docker -v
+    exit-status: 0
     stdout:
       - 24.0.7
   docker_buildx:
     exec: docker buildx version
+    exit-status: 0
   docker_compose:
     exec: docker-compose -v
+    exit-status: 0
     stdout:
       - 2.23.3
   doctl:
     exec: doctl version
+    exit-status: 0
     stdout:
       - 1.101.0
   gh_cli:
     exec: gh --version
+    exit-status: 0
     stdout:
       - 2.40.1
   git:
     exec: git --version
+    exit-status: 0
     stdout:
       - 2.43.0
   git_lfs:
     exec: git-lfs --version
+    exit-status: 0
     stdout:
       - 3.4.1
   goss:
     exec: goss --version
+    exit-status: 0
     stdout:
       - 0.4.4
   hadolint:
     exec: hadolint -v
+    exit-status: 0
     stdout:
       - 2.12.0
   jdk11:
     exec: /opt/jdk-11/bin/java --version
+    exit-status: 0
     stdout:
       - 11.0.21+9
   jdk17:
     exec: /opt/jdk-17/bin/java --version
+    exit-status: 0
     stdout:
       - 17.0.8.1+1
   jdk21:
     exec: /opt/jdk-21/bin/java --version
+    exit-status: 0
     stdout:
       - 21.0.1+12
   jdk8:
     exec: /opt/jdk-8/bin/java -version
+    exit-status: 0
     stderr:
       - 1.8.0_392
   jq:
     exec: jq --version
+    exit-status: 0
     stdout:
       - jq-1.6
   jx-release-version:
     exec: jx-release-version -version
+    exit-status: 0
     stdout:
       - 2.7.0
   kubectl:
     exec: kubectl version --client
+    exit-status: 0
     stdout:
       - 1.23.13
   launchable:
     exec: launchable --version
+    exit-status: 0
     stdout:
       - 1.66.0
   make:
     exec: make --version
+    exit-status: 0
   maven:
     exec: mvn -v
+    exit-status: 0
     stdout:
       - 3.9.6
   netlify-deploy:
     exec: netlify-deploy --help
+    exit-status: 0
   nodejs:
     exec: node --version
+    exit-status: 0
     stdout:
       - 18.18.2
   npm:
     exec: npm version
+    exit-status: 0
   packer:
     exec: packer -v
+    exit-status: 0
     stdout:
       - 1.10.0
   parallel:
     exec: parallel --version
+    exit-status: 0
   playwright:
     exec: playwright --version
+    exit-status: 0
     stdout:
       - 1.40.1
   python3:
     exec: python3 --version
+    exit-status: 0
   ruby:
     exec: ruby -v
+    exit-status: 0
     stdout:
       - 2.6.10
   ssh_agent:
     exec: command -v ssh-agent
+    exit-status: 0
   terraform:
     exec: terraform -v
+    exit-status: 0
     stdout:
       - 1.6.6
   trivy:
     exec: trivy --version
+    exit-status: 0
     stdout:
       - 0.47.0
   unzip:
     exec: unzip -v
+    exit-status: 0
   updatecli:
     exec: updatecli version
+    exit-status: 0
     stderr:
       - 0.69.0
   vagrant:
     exec: vagrant -v
+    exit-status: 0
   yq:
     exec: yq --version
+    exit-status: 0
     stdout:
       - 4.25.3
   zip:
     exec: zip -v
+    exit-status: 0
 file:
   /home/jenkins:
     contains: []

--- a/goss/goss-windows.yaml
+++ b/goss/goss-windows.yaml
@@ -1,123 +1,155 @@
 command:
   Powershell:
     exec: powershell (Get-Host).Version
+    exit-status: 0
   awscli:
     exec: aws --version
+    exit-status: 0
     stdout:
       - 2.15.2
   azurecli:
     exec: az version
+    exit-status: 0
     stdout:
       - 2.55.0
   bundle:
     exec: bundle -v
+    exit-status: 0
   chocolatey:
     exec: choco
     exit-status: 1
   container-structure-test:
     exec: container-structure-test version
+    exit-status: 0
     stdout:
       - 1.16.0
   default_java:
     exec: java --version
+    exit-status: 0
     stdout:
       - 11.0.21+9
   docker-ce:
     exec: docker -v
+    exit-status: 0
   docker_compose:
     exec: docker-compose -v
+    exit-status: 0
     stdout:
       - 2.23.3
   gh_cli:
     exec: gh version
+    exit-status: 0
     stdout:
       - 2.40.1
   git_lfs:
     exec: git-lfs version
+    exit-status: 0
     stdout:
       - 3.4.1
   goss:
     exec: goss -version
+    exit-status: 0
     stdout:
       - 0.4.4
   hadolint:
     exec: hadolint --version
+    exit-status: 0
     stdout:
       - 2.12.0
   jdk11:
     exec: C:\tools\jdk-11\bin\java --version
+    exit-status: 0
     stdout:
       - 11.0.21+9
   jdk17:
     exec: C:\tools\jdk-17\bin\java --version
+    exit-status: 0
     stdout:
       - 17.0.8.1+1
   jdk21:
     exec: C:\tools\jdk-21\bin\java --version
+    exit-status: 0
     stdout:
       - 21.0.1+12
   jdk8:
     exec: C:\tools\jdk-8\bin\java -version
+    exit-status: 0
     stderr:
       - 1.8.0_392
   jq:
     exec: jq --version
+    exit-status: 0
     stdout:
       - jq-1.6
   jx-release-version:
     exec: jx-release-version -version
+    exit-status: 0
     stdout:
       - 2.7.0
   kubectl:
     exec: kubectl version --client
+    exit-status: 0
     stdout:
       - 1.23.13
   launchable:
     exec: launchable --version
+    exit-status: 0
     stdout:
       - 1.66.0
   make:
     exec: make -version
+    exit-status: 0
   netlify-deploy:
     exec: netlify-deploy --help
+    exit-status: 0
   nodejs:
     exec: node --version
+    exit-status: 0
     stdout:
       - 18.18.2
   packer:
     exec: packer --version
+    exit-status: 0
     stdout:
       - 1.10.0
   pwsh:
     exec: pwsh -command "(Get-Host).Version"
+    exit-status: 0
     stdout:
       - /7.*4.*0/
   python3:
     exec: python --version
+    exit-status: 0
     stdout:
       - 3.12.1
   ruby:
     exec: ruby -v
+    exit-status: 0
     stdout:
       - 2.6.10
   terraform:
     exec: terraform -v
+    exit-status: 0
     stdout:
       - 1.6.6
   trivy:
     exec: trivy --version
+    exit-status: 0
     stdout:
       - 0.47.0
   updatecli:
     exec: updatecli version
+    exit-status: 0
     stderr:
       - 0.69.0
   vagrant:
     exec: vagrant --version
+    exit-status: 0
     stdout:
       - 2.4.0
   yq:
     exec: yq --version
+    exit-status: 0
     stdout:
       - 4.25.3
 file:


### PR DESCRIPTION
following #940 the exit-status is required