### PR TITLE
fix(yq) downgrade to 4.25.3

### DIFF
--- a/goss/goss-linux.yaml
+++ b/goss/goss-linux.yaml
@@ -195,7 +195,7 @@ command:
     exec: yq --version
     exit-status: 0
     stdout:
-      - 4.40.5
+      - 4.25.3
   zip:
     exec: zip -v
     exit-status: 0

--- a/goss/goss-windows.yaml
+++ b/goss/goss-windows.yaml
@@ -151,7 +151,7 @@ command:
     exec: yq --version
     exit-status: 0
     stdout:
-      - 4.40.5
+      - 4.25.3
 file:
   C:\Program Files\Chromium\Application\:
     contains: []

--- a/provisioning/tools-versions.yml
+++ b/provisioning/tools-versions.yml
@@ -37,5 +37,5 @@ updatecli_version: 0.70.0
 vagrant_version: 2.4.0
 windows_pwsh_version: 7.4.0
 xq_version: 1.2.3
-yq_version: 4.40.5
+yq_version: 4.25.3
 playwright_version: 1.40.1

--- a/updatecli/updatecli.d/yq.yml
+++ b/updatecli/updatecli.d/yq.yml
@@ -27,6 +27,14 @@ sources:
     transformers:
       - trimprefix: v
 
+conditions:
+  checkForChocolateyPackage:
+    kind: http
+    disablesourceinput: true # Do not pass source as argument to the command line
+    spec:
+      url: https://community.chocolatey.org/packages/yq/{{ source "lastReleaseVersion" }}
+      # command: curl https://community.chocolatey.org/packages/awscli/{{ source "lastReleaseVersion" }} --silent --show-error --location --fail --output /dev/null
+
 targets:
   updateVersion:
     name: Update the `yq` version in the provision-env.yml file


### PR DESCRIPTION
Reverts #956 as `yq` version `4.40.5` is not available (yet) in chocolatey packages.

It also fixes the updatecli manifest to check for chocolatey package (to avoid opening a PR if not available yet).