### PR TITLE
hotfix(docker): add golang to path

### DIFF
--- a/sources.pkr.hcl
+++ b/sources.pkr.hcl
@@ -55,6 +55,7 @@ source "docker" "base" {
     "ENV LANGUAGE=${element(split(".", var.locale), 0)}:${element(split("_", var.locale), 0)}",
     "ENV LC_ALL=${var.locale}",
     "ENV AGENT_WORKDIR=/home/jenkins/agent",
+    "ENV PATH=$${PATH}:/usr/local/go/bin",
     "WORKDIR /home/jenkins",
     "ENTRYPOINT [\"/usr/local/bin/jenkins-agent\"]",
     "USER jenkins",


### PR DESCRIPTION
follow #981 as per https://github.com/jenkins-infra/helpdesk/issues/3823#issuecomment-1887188512