### PR TITLE
Revert "Bump vagrant version to 2.4.1"

### DIFF
--- a/goss/goss-windows.yaml
+++ b/goss/goss-windows.yaml
@@ -42,7 +42,7 @@ command:
     exec: vagrant --version
     exit-status: 0
     stdout:
-      - 2.4.1
+      - 2.4.0
 file:
   C:\Program Files\Chromium\Application\:
     contains: []

--- a/provisioning/tools-versions.yml
+++ b/provisioning/tools-versions.yml
@@ -42,7 +42,7 @@ sops_version: 3.8.1
 terraform_version: 1.6.6
 trivy_version: 0.48.3
 updatecli_version: 0.71.0
-vagrant_version: 2.4.1
+vagrant_version: 2.4.0
 windows_pwsh_version: 7.4.1
 xq_version: 1.2.3
 yq_version: 4.25.3


### PR DESCRIPTION
Reverts jenkins-infra/packer-images#1009

Because:

```
ERROR: could not find version 2.4.1 for vagrant. Output of apt-cache madison is:    
vagrant |    2.4.0-1 | <a href='https://apt.releases.hashicorp.com'>https://apt.releases.hashicorp.com</a> jammy/main amd64 Packages
# ...
```

It seems https://github.com/jenkins-infra/packer-images/blob/e32a8483f7d17d60ce070b5fad7dbc5f76d49b90/updatecli/updatecli.d/vagrant.yml#L30-L36 only checks for chocolatey but not for APT packages in `amd64` (`arm64` only uses the "latest") alas)
