### PR TITLE
feat(ubuntu): add `dnsutils` to common requirements install

### DIFF
--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -99,6 +99,7 @@ function install_common_requirements() {
     apt-transport-https \
     ca-certificates `# Adds certificate authority for proper use of TLS` \
     curl `# A nice HTTP client` \
+    dnsutils `# Provides dig(1)` \
     lsb-release `# Provides CLI for distribution detction` \
     gpg-agent `# Required for GPG management` \
     software-properties-common `# Provides a LOT of APT utilities`


### PR DESCRIPTION
This PR adds `dnsutils` to the common requirements installed in order to provide dig(1), used in https://github.com/jenkins-infra/infra-reports/pull/55.