### PR TITLE
chore: update `inbound-agent` repo in docker-jenkins-agent.sh

### DIFF
--- a/provisioning/docker-jenkins-agent.sh
+++ b/provisioning/docker-jenkins-agent.sh
@@ -14,5 +14,5 @@ chmod 755 /usr/share/jenkins
 chmod 644 /usr/share/jenkins/agent.jar
 
 echo "= Retrieve jenkins-agent script"
-curl --create-dirs --fail --silent --show-error --location --output /usr/local/bin/jenkins-agent https://raw.githubusercontent.com/jenkinsci/docker-inbound-agent/master/jenkins-agent
+curl --create-dirs --fail --silent --show-error --location --output /usr/local/bin/jenkins-agent https://raw.githubusercontent.com/jenkinsci/docker-agent/master/jenkins-agent
 chmod a+x /usr/local/bin/jenkins-agent


### PR DESCRIPTION
This PR replaces https://github.com/jenkinsci/docker-inbound-agent by https://github.com/jenkinsci/docker-agent.

Follow-up of:
- https://github.com/jenkinsci/docker-agent/pull/570

Ref:
- https://github.com/jenkinsci/docker-agent/issues/569