### PR TITLE
chore: separate updatecli to its own pipeline

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -90,28 +90,6 @@ pipeline {
             }
           }
         }
-        stage('Updatecli') {
-          steps {
-            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-              script {
-                // TODO: Implement https://github.com/jenkins-infra/pipeline-library/issues/518 to allow using the updatecli() library function
-                withCredentials([
-                  usernamePassword(
-                  credentialsId: 'github-app-updatecli-on-jenkins-infra',
-                  usernameVariable: 'USERNAME_VALUE', // Setting this variable is mandatory, even if of not used when the credentials is a githubApp one
-                  passwordVariable: 'UPDATECLI_GITHUB_TOKEN'
-                  )
-                ]) {
-                  sh 'updatecli version'
-                  sh 'updatecli diff --values ./updatecli/values.yaml --config ./updatecli/updatecli.d'
-                  if (env.BRANCH_IS_PRIMARY) {
-                    sh 'updatecli apply --values ./updatecli/values.yaml --config ./updatecli/updatecli.d'
-                  }
-                }
-              }
-            }
-          }
-        }
       }
     }
     stage('Packer Images') {

--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -1,0 +1,4 @@
+updatecli(action: 'diff')
+if (env.BRANCH_IS_PRIMARY) {
+    updatecli(action: 'apply', cronTriggerExpression: '@daily')
+}

--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -1,4 +1,4 @@
-updatecli(action: 'diff')
+updatecli(action: 'diff', updatecliAgentLabel: 'linux-amd64-docker')
 if (env.BRANCH_IS_PRIMARY) {
-    updatecli(action: 'apply', cronTriggerExpression: '@daily')
+    updatecli(action: 'apply', updatecliAgentLabel: 'linux-amd64-docker', cronTriggerExpression: '@daily')
 }


### PR DESCRIPTION
This PR separates updatecli to its own pipeline, taking in account https://github.com/jenkins-infra/packer-images/pull/606#pullrequestreview-1389903782 and using the new `updatecliAgentLabel` option of the `updatecli` shared pipeline function to use a Docker agent for running updatecli.

Supersedes and closes https://github.com/jenkins-infra/packer-images/pull/606

Follow-up of:
- https://github.com/jenkins-infra/kubernetes-management/pull/3855

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/2778