### PR TITLE
fix(ubuntu) correct asdf inclusion in `/etc/environment` for Linux VMs

### DIFF
--- a/build-jenkins-agent-ubuntu.pkr.hcl
+++ b/build-jenkins-agent-ubuntu.pkr.hcl
@@ -51,7 +51,7 @@ build {
   }
 
   provisioner "shell" {
-    execute_command = "{{ .Vars }} sudo -E su - jenkins -c \"bash -eu '{{ .Path }}'\""
+    execute_command = "{{ .Vars }} sudo -E su - jenkins -c \"bash -eux '{{ .Path }}'\""
     inline = [
       "source /home/jenkins/.asdf/asdf.sh", # Required as this is a non-interactive and non-login `bash`
       "goss --version",

--- a/build-jenkins-agent-ubuntu.pkr.hcl
+++ b/build-jenkins-agent-ubuntu.pkr.hcl
@@ -54,6 +54,7 @@ build {
     execute_command = "{{ .Vars }} sudo -E su - jenkins -c \"bash -eux '{{ .Path }}'\""
     inline = [
       "source /home/jenkins/.asdf/asdf.sh && asdf list", # Required as this is a non-interactive and non-login `bash`
+      "echo $PATH && cat /etc/environment",
       "goss --version",
       "goss --gossfile /tmp/goss-linux.yaml --loglevel DEBUG validate",
       "goss --gossfile /tmp/goss-common.yaml --loglevel DEBUG validate",

--- a/build-jenkins-agent-ubuntu.pkr.hcl
+++ b/build-jenkins-agent-ubuntu.pkr.hcl
@@ -53,7 +53,7 @@ build {
   provisioner "shell" {
     execute_command = "{{ .Vars }} sudo -E su - jenkins -c \"bash -eux '{{ .Path }}'\""
     inline = [
-      "source /home/jenkins/.asdf/asdf.sh", # Required as this is a non-interactive and non-login `bash`
+      "source /home/jenkins/.asdf/asdf.sh && asdf list", # Required as this is a non-interactive and non-login `bash`
       "goss --version",
       "goss --gossfile /tmp/goss-linux.yaml --loglevel DEBUG validate",
       "goss --gossfile /tmp/goss-common.yaml --loglevel DEBUG validate",

--- a/build-jenkins-agent-ubuntu.pkr.hcl
+++ b/build-jenkins-agent-ubuntu.pkr.hcl
@@ -51,10 +51,9 @@ build {
   }
 
   provisioner "shell" {
-    execute_command = "{{ .Vars }} sudo -E su - jenkins -c \"bash -eux '{{ .Path }}'\""
+    execute_command = "{{ .Vars }} sudo -E su - jenkins -c \"bash -eu '{{ .Path }}'\""
     inline = [
-      "source /home/jenkins/.asdf/asdf.sh && asdf list", # Required as this is a non-interactive and non-login `bash`
-      "echo $PATH && cat /etc/environment",
+      "source /home/jenkins/.asdf/asdf.sh", # Required as this is a non-interactive and non-login `bash`
       "goss --version",
       "goss --gossfile /tmp/goss-linux.yaml --loglevel DEBUG validate",
       "goss --gossfile /tmp/goss-common.yaml --loglevel DEBUG validate",

--- a/goss/goss-common.yaml
+++ b/goss/goss-common.yaml
@@ -95,8 +95,9 @@ command:
   ruby:
     exec: ruby -v
     exit-status: 0
-    stdout:
-      - 2.6.10
+    # https://github.com/jenkins-infra/packer-images/pull/1043#pullrequestreview-1878135249
+    # stdout:
+    #   - 2.6.10
   terraform:
     exec: terraform -v
     exit-status: 0

--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -157,7 +157,7 @@ function install_asdf() {
 
   ## append to the system wide path variable, need to be seconded for docker in packer sources.pkr.hcl
   ## https://backreference.org/2010/02/20/using-different-delimiters-in-sed/index.html
-  sed --in-place --regexp-extended "s|^PATH=(.*)\"|PATH=\1:${asdf_install_dir}/shims:${asdf_install_dir}/bin\"|g" /etc/environment
+  sed --in-place --regexp-extended "s|^PATH=(.*)\"$|PATH=\1:${asdf_install_dir}/shims:${asdf_install_dir}/bin\"|" /etc/environment
 }
 
 ## Install the ASDF Plugin passed as argument ($1 is the name and $2 the URL)

--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -157,7 +157,7 @@ function install_asdf() {
 
   ## append to the system wide path variable, need to be seconded for docker in packer sources.pkr.hcl
   ## https://backreference.org/2010/02/20/using-different-delimiters-in-sed/index.html
-  sed --regexp-extended "s|^PATH=(.*)"$|PATH=/\1:${asdf_install_dir}/shims:${asdf_install_dir}/bin"|" /etc/environment
+  sed -R -E "s|^PATH=(.*)"$|PATH=\1:${asdf_install_dir}/shims:${asdf_install_dir}/bin"|" /etc/environment
 }
 
 ## Install the ASDF Plugin passed as argument ($1 is the name and $2 the URL)

--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -156,7 +156,8 @@ function install_asdf() {
   rm -f "${archive}"
 
   ## append to the system wide path variable, need to be seconded for docker in packer sources.pkr.hcl
-  sed --regexp-extended "s|^PATH=(.*)"$|PATH=|\1:${asdf_install_dir}/shims:${asdf_install_dir}/bin"|" /etc/environment
+  ## https://backreference.org/2010/02/20/using-different-delimiters-in-sed/index.html
+  sed --regexp-extended "s|^PATH=(.*)"$|PATH=/\1:${asdf_install_dir}/shims:${asdf_install_dir}/bin"|" /etc/environment
 }
 
 ## Install the ASDF Plugin passed as argument ($1 is the name and $2 the URL)

--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -157,7 +157,7 @@ function install_asdf() {
 
   ## append to the system wide path variable, need to be seconded for docker in packer sources.pkr.hcl
   ## https://backreference.org/2010/02/20/using-different-delimiters-in-sed/index.html
-  sed --regexp-extended "s|^PATH=\(.*\)"$|PATH=\1:${asdf_install_dir}/shims:${asdf_install_dir}/bin"|" /etc/environment
+  sed --regexp-extended "s|^PATH=\(.*\)\"$|PATH=\1:${asdf_install_dir}/shims:${asdf_install_dir}/bin\"|" /etc/environment
 }
 
 ## Install the ASDF Plugin passed as argument ($1 is the name and $2 the URL)

--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -156,7 +156,7 @@ function install_asdf() {
   rm -f "${archive}"
 
   ## append to the system wide path variable, need to be seconded for docker in packer sources.pkr.hcl
-  sed -e '/^PATH/s/"$/:\/home\/jenkins\/.asdf\/shims:\/home\/jenkins\/.asdf\/bin\"/g' -i /etc/environment
+  sed --regexp-extended "s|^PATH=(.*)"$|PATH=\1:${asdf_install_dir}/shims:${asdf_install_dir}/bin"|" -i /etc/environment
 }
 
 ## Install the ASDF Plugin passed as argument ($1 is the name and $2 the URL)

--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -156,7 +156,7 @@ function install_asdf() {
   rm -f "${archive}"
 
   ## append to the system wide path variable, need to be seconded for docker in packer sources.pkr.hcl
-  sed --regexp-extended "s|^PATH=(.*)"$|PATH=\1:${asdf_install_dir}/shims:${asdf_install_dir}/bin"|" /etc/environment
+  sed --regexp-extended "s|^PATH=(.*)"$|PATH=|\1:${asdf_install_dir}/shims:${asdf_install_dir}/bin"|" /etc/environment
 }
 
 ## Install the ASDF Plugin passed as argument ($1 is the name and $2 the URL)

--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -716,8 +716,8 @@ function main() {
   install_gh
   install_golang
   install_golangcilint # must come after golang
-  install_vagrant
   install_ruby
+  install_vagrant
   install_xq
   install_yq
   install_packer

--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -157,7 +157,7 @@ function install_asdf() {
 
   ## append to the system wide path variable, need to be seconded for docker in packer sources.pkr.hcl
   ## https://backreference.org/2010/02/20/using-different-delimiters-in-sed/index.html
-  sed -R -E "s|^PATH=(.*)"$|PATH=\1:${asdf_install_dir}/shims:${asdf_install_dir}/bin"|" /etc/environment
+  sed --regexp-extended "s|^PATH=\(.*\)"$|PATH=\1:${asdf_install_dir}/shims:${asdf_install_dir}/bin"|" /etc/environment
 }
 
 ## Install the ASDF Plugin passed as argument ($1 is the name and $2 the URL)

--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -157,7 +157,7 @@ function install_asdf() {
 
   ## append to the system wide path variable, need to be seconded for docker in packer sources.pkr.hcl
   ## https://backreference.org/2010/02/20/using-different-delimiters-in-sed/index.html
-  sed --regexp-extended "s|^PATH=\(.*\)\"$|PATH=\1:${asdf_install_dir}/shims:${asdf_install_dir}/bin\"|" /etc/environment
+  sed --in-place --regexp-extended "s|^PATH=(.*)\"|PATH=\1:${asdf_install_dir}/shims:${asdf_install_dir}/bin\"|g" /etc/environment
 }
 
 ## Install the ASDF Plugin passed as argument ($1 is the name and $2 the URL)

--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -156,7 +156,7 @@ function install_asdf() {
   rm -f "${archive}"
 
   ## append to the system wide path variable, need to be seconded for docker in packer sources.pkr.hcl
-  sed -e "/^PATH/s/\"$/:\${asdf_install_dir}\/shims:\${asdf_install_dir}\/bin\"/g" -i /etc/environment
+  sed -e '/^PATH/s/"$/:\/home\/jenkins\/.asdf\/shims:\/home\/jenkins\/.asdf\/bin\"/g' -i /etc/environment
 }
 
 ## Install the ASDF Plugin passed as argument ($1 is the name and $2 the URL)

--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -156,7 +156,7 @@ function install_asdf() {
   rm -f "${archive}"
 
   ## append to the system wide path variable, need to be seconded for docker in packer sources.pkr.hcl
-  sed --regexp-extended "s|^PATH=(.*)"$|PATH=\1:${asdf_install_dir}/shims:${asdf_install_dir}/bin"|" -i /etc/environment
+  sed --regexp-extended "s|^PATH=(.*)"$|PATH=\1:${asdf_install_dir}/shims:${asdf_install_dir}/bin"|" /etc/environment
 }
 
 ## Install the ASDF Plugin passed as argument ($1 is the name and $2 the URL)


### PR DESCRIPTION
This PR uses hardcoded path to include asdf in the $PATH so asdf installed tools like yq can be executed.

Note: there might be a way to keep this folder as a variable but as it breaks current uses this "easy" solution should be enough, can be revised in a following pull request.

Ref:
- #1042 