### PR TITLE
BUMP(kubectl): upgrade to the 1.26.xx

### DIFF
--- a/provisioning/tools-versions.yml
+++ b/provisioning/tools-versions.yml
@@ -29,7 +29,7 @@ jdk8_version: 8u402-b06
 jenkins_remoting_version: 3206.vb_15dcf73f6a_9
 jq_version: 1.6
 jxreleaseversion_version: 2.7.3
-kubectl_version: 1.23.13
+kubectl_version: 1.26.12
 launchable_version: 1.66.0
 maven_version: 3.9.6
 netlifydeploy_version: 0.1.8


### PR DESCRIPTION
to be compliant with https://github.com/jenkins-infra/docker-helmfile/blob/e8d7fc943b557d32352663fb5acd5b2868334396/Dockerfile#L32