### PR TITLE
chore(updatecli) add a manifest to bump kubectl with pattern

### DIFF
--- a/updatecli/updatecli.d/kubectl.yaml
+++ b/updatecli/updatecli.d/kubectl.yaml
@@ -1,0 +1,56 @@
+---
+name: Bump `KUBECTL` version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastReleaseVersion:
+    kind: githubrelease
+    name: Get the latest `KUBECTL` CLI version
+    transformers:
+      - trimprefix: "kubernetes-"
+    spec:
+      owner: "kubernetes"
+      repository: "kubectl"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: regex
+        pattern: "^kubernetes-1.26.(\\d*)$"
+
+targets:
+  updateVersion:
+    name: "Update the `KUBECTL` version in the tools-versions.yml file"
+    sourceid: lastReleaseVersion
+    kind: yaml
+    spec:
+      file: provisioning/tools-versions.yml
+      key: $.kubectl_version
+    scmid: default
+  updateVersionInGoss:
+    name: Update the `KUBECTL` version in the goss test
+    kind: yaml
+    spec:
+      file: goss/goss-common.yaml
+      key: $.command.kubectl.stdout[0]
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    title: Bump KUBECTL version to {{ source "lastReleaseVersion" }}
+    scmid: default
+    spec:
+      labels:
+        - enhancement
+        - KUBECTL

--- a/updatecli/updatecli.d/kubectl.yaml
+++ b/updatecli/updatecli.d/kubectl.yaml
@@ -1,5 +1,5 @@
 ---
-name: Bump `KUBECTL` version
+name: Bump `kubectl` version
 
 scms:
   default:
@@ -16,7 +16,7 @@ scms:
 sources:
   lastReleaseVersion:
     kind: githubrelease
-    name: Get the latest `KUBECTL` CLI version
+    name: Get latest `kubectl` CLI version
     transformers:
       - trimprefix: "kubernetes-"
     spec:
@@ -30,7 +30,7 @@ sources:
 
 targets:
   updateVersion:
-    name: "Update the `KUBECTL` version in the tools-versions.yml file"
+    name: "Update `kubectl` version in the tools-versions.yml file"
     sourceid: lastReleaseVersion
     kind: yaml
     spec:
@@ -38,7 +38,7 @@ targets:
       key: $.kubectl_version
     scmid: default
   updateVersionInGoss:
-    name: Update the `KUBECTL` version in the goss test
+    name: Update `kubectl` version in the goss test
     kind: yaml
     spec:
       file: goss/goss-common.yaml
@@ -48,9 +48,9 @@ targets:
 actions:
   default:
     kind: github/pullrequest
-    title: Bump KUBECTL version to {{ source "lastReleaseVersion" }}
+    title: Bump `kubectl` version to {{ source "lastReleaseVersion" }}
     scmid: default
     spec:
       labels:
-        - enhancement
-        - KUBECTL
+        - dependencies
+        - kubectl


### PR DESCRIPTION
This PR adds the missing updatecli manifest to keep `kubectl` up to date.

We drifted from https://github.com/jenkins-infra/docker-helmfile/blob/e8d7fc943b557d32352663fb5acd5b2868334396/Dockerfile#L32