### PR TITLE
chore(updatecli) track kubernetes 1.27.x baseline

### DIFF
--- a/updatecli/updatecli.d/kubectl.yaml
+++ b/updatecli/updatecli.d/kubectl.yaml
@@ -26,7 +26,7 @@ sources:
       username: "{{ .github.username }}"
       versionfilter:
         kind: regex
-        pattern: "^kubernetes-1.26.(\\d*)$"
+        pattern: "^kubernetes-1.27.(\\d*)$"
 
 targets:
   updateVersion:


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/3948