### PR TITLE
chore: restore ruby version goss check for Linux

### DIFF
--- a/goss/goss-common.yaml
+++ b/goss/goss-common.yaml
@@ -92,12 +92,6 @@ command:
     exit-status: 0
     stdout:
       - 1.10.0
-  ruby:
-    exec: ruby -v
-    exit-status: 0
-    # https://github.com/jenkins-infra/packer-images/pull/1043#pullrequestreview-1878135249
-    # stdout:
-    #   - 2.6.10
   terraform:
     exec: terraform -v
     exit-status: 0

--- a/goss/goss-linux.yaml
+++ b/goss/goss-linux.yaml
@@ -102,6 +102,12 @@ command:
   python3:
     exec: python3 --version
     exit-status: 0
+  # https://github.com/jenkins-infra/packer-images/pull/1043#pullrequestreview-1878135249
+  ruby:
+    exec: asdf list ruby
+    exit-status: 0
+    stdout:
+      - 2.6.10
   sops:
     exec: sops --version
     exit-status: 0

--- a/goss/goss-windows.yaml
+++ b/goss/goss-windows.yaml
@@ -41,6 +41,8 @@ command:
   ruby:
     exec: ruby -v
     exit-status: 0
+    stdout:
+      - 2.6.10
   vagrant:
     exec: vagrant --version
     exit-status: 0

--- a/goss/goss-windows.yaml
+++ b/goss/goss-windows.yaml
@@ -38,6 +38,9 @@ command:
     exit-status: 0
     stdout:
       - 3.12.2
+  ruby:
+    exec: ruby -v
+    exit-status: 0
   vagrant:
     exec: vagrant --version
     exit-status: 0


### PR DESCRIPTION
This PR uses `asdf list ruby` to retrieve the version installed by asdf and not the vagrant one, cf https://github.com/jenkins-infra/packer-images/pull/1043#pullrequestreview-1878135249

Note: I wasn't sure if goss would have kept the linux version on its config merge if I kept the less precise ruby check in goss-common.yaml, hence the move of the existing one to goss-windows.yaml.

Follow-up of:
- #1043 

Ref:
- #1042 