### PR TITLE
fix(ubuntu) prefer `asdf` tools over system tools in default `PATH`es

### DIFF
--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -158,7 +158,7 @@ function install_asdf() {
 
   ## append to the system wide path variable, need to be seconded for docker in packer sources.pkr.hcl
   ## https://backreference.org/2010/02/20/using-different-delimiters-in-sed/index.html
-  sed --in-place --regexp-extended "s|^PATH=(.*)\"$|PATH=\1:${asdf_install_dir}/shims:${asdf_install_dir}/bin\"|" /etc/environment
+  sed --in-place --regexp-extended "s|^PATH=\"(.*)\"$|PATH=\"${asdf_install_dir}/shims:${asdf_install_dir}/bin:\1\"|" /etc/environment
 }
 
 ## Install the ASDF Plugin passed as argument ($1 is the name and $2 the URL)

--- a/sources.pkr.hcl
+++ b/sources.pkr.hcl
@@ -55,7 +55,7 @@ source "docker" "base" {
     "ENV LANGUAGE=${element(split(".", var.locale), 0)}:${element(split("_", var.locale), 0)}",
     "ENV LC_ALL=${var.locale}",
     "ENV AGENT_WORKDIR=/home/jenkins/agent",
-    "ENV PATH=$${PATH}:/usr/local/go/bin:/home/jenkins/.asdf/shims:/home/jenkins/.asdf/bin",
+    "ENV PATH=/usr/local/go/bin:/home/jenkins/.asdf/shims:/home/jenkins/.asdf/bin:$${PATH}",
     "WORKDIR /home/jenkins",
     "ENTRYPOINT [\"/usr/local/bin/jenkins-agent\"]",
     "USER jenkins",


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/3823#issuecomment-1918890269

this PR fixes the default ruby version on linux arm64 agents (both VM and container).

we expect ruby 2.6.10 to be the default (only used by puppet) but vagrant ubuntu package on linux arm64 adds ruby 3.0 as explicit dependency. Note that the difference between amd64 and arm64 is due to mismatch version of vagrant: https://github.com/jenkins-infra/packer-images/blob/3a28057d3b4a29c9834d25d9f1ccd9dde82fd8b7/provisioning/ubuntu-provision.sh#L480-L496
