### PR TITLE
feat(ubuntu): include `get-fileshare-signed-url.sh` script

### DIFF
--- a/build-jenkins-agent-ubuntu.pkr.hcl
+++ b/build-jenkins-agent-ubuntu.pkr.hcl
@@ -25,6 +25,11 @@ build {
   }
 
   provisioner "file" {
+    source      = "./provisioning/get-fileshare-signed-url.sh"
+    destination = "/tmp/get-fileshare-signed-url.sh"
+  }
+
+  provisioner "file" {
     source      = "./gpg-keys"
     destination = "/tmp/gpg-keys"
   }

--- a/provisioning/get-fileshare-signed-url.sh
+++ b/provisioning/get-fileshare-signed-url.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -eu -o pipefail
+
+: "${JENKINS_INFRA_FILESHARE_CLIENT_ID?}" "${JENKINS_INFRA_FILESHARE_CLIENT_SECRET?}" "${JENKINS_INFRA_FILESHARE_TENANT_ID?}" "${STORAGE_FILESHARE?}" "${STORAGE_NAME?}" "${STORAGE_DURATION_IN_MINUTE?}" "${STORAGE_PERMISSIONS?}"
+
+# Don't print any command
+set +x
+
+# Login without the JSON output from az
+az login --service-principal --user "${JENKINS_INFRA_FILESHARE_CLIENT_ID}" --password "${JENKINS_INFRA_FILESHARE_CLIENT_SECRET}" --tenant "${JENKINS_INFRA_FILESHARE_TENANT_ID}" > /dev/null
+
+# Generate a SAS token, remove double quotes around it and replace potential '/' by '%2F'
+expiry=$(date --utc --date "+ ${STORAGE_DURATION_IN_MINUTE} minutes" +"%Y-%m-%dT%H:%MZ")
+token=$(az storage share generate-sas \
+--name "${STORAGE_FILESHARE}" \
+--account-name "${STORAGE_NAME}" \
+--https-only \
+--permissions "${STORAGE_PERMISSIONS}" \
+--expiry "${expiry}" \
+--only-show-errors \
+| sed 's/\"//g' \
+| sed 's|/|%2F|g')
+
+az logout
+
+echo "https://${STORAGE_NAME}.file.core.windows.net/${STORAGE_FILESHARE}/?${token}"

--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -67,8 +67,8 @@ function install_package_version() {
 
 ## Copy custom scripts
 function copy_custom_scripts() {
-  cp /tmp/add_auth_key_to_user.sh /usr/local/bin/add_auth_key_to_user.sh
-  chmod a+x /usr/local/bin/add_auth_key_to_user.sh
+  cp /tmp/{add_auth_key_to_user.sh,get-fileshare-signed-url.sh} /usr/local/bin/
+  chmod a+x /usr/local/bin/add_auth_key_to_user.sh /usr/local/bin/get-fileshare-signed-url.sh
 }
 
 ## Set the locale


### PR DESCRIPTION
This PR includes the script from the shared pipeline library to generate short-lived SAS token for a File Share with a service principal so it's available for trusted.ci.jenkins.io jobs running on ephemeral agents.

Will be completed in another pull request by an updatecli manifest to keep the script up to date while maintaining the control on when it's updated.

Follow-up of:
- https://github.com/jenkins-infra/jenkins-infra/pull/3323

Ref:
- https://github.com/jenkins-infra/crawler/pull/144#issuecomment-1985450221
- https://github.com/jenkins-infra/helpdesk/issues/3414#issuecomment-1973817455