### PR TITLE
feat(nodejs) Bump updatecli manifest to install new nodejs LTS 20.x.x

### DIFF
--- a/updatecli/updatecli.d/nodejs.yml
+++ b/updatecli/updatecli.d/nodejs.yml
@@ -24,7 +24,7 @@ sources:
       username: "{{ .github.username }}"
       versionfilter:
         kind: regex
-        pattern: v18.(\d*).(\d*)
+        pattern: v20.(\d*).(\d*)
     transformers:
       - trimprefix: v
 


### PR DESCRIPTION
to follow docker-builder image versions : https://github.com/jenkins-infra/docker-builder/commit/db07be9b0c19172f1af9a7f2186e28b5950ec4de