### PR TITLE
feat(nodejs): split the version between linux and windows

### DIFF
--- a/goss/goss-common.yaml
+++ b/goss/goss-common.yaml
@@ -74,12 +74,6 @@ command:
   netlify-deploy:
     exec: netlify-deploy --help
     exit-status: 0
-  nodejs:
-    exec: node --version
-    exit-status: 0
-    stdout:
-      - 20.11.1
-      - '!Please install a version by running one of the following'
   npm:
     exec: npm --version
     exit-status: 0

--- a/goss/goss-linux.yaml
+++ b/goss/goss-linux.yaml
@@ -86,6 +86,12 @@ command:
     exit-status: 0
     stdout:
       - 3.9.6
+  nodejs:
+    exec: node --version
+    exit-status: 0
+    stdout:
+      - 20.11.1
+      - '!Please install a version by running one of the following'
   parallel:
     exec: parallel --version
     exit-status: 0

--- a/goss/goss-windows.yaml
+++ b/goss/goss-windows.yaml
@@ -28,6 +28,12 @@ command:
     exit-status: 0
     stderr:
       - 1.8.0_402
+  nodejs:
+    exec: node --version
+    exit-status: 0
+    stdout:
+      - 20.11.1
+      - '!Please install a version by running one of the following'
   pwsh:
     exec: pwsh -command "(Get-Host).Version"
     exit-status: 0

--- a/provisioning/tools-versions.yml
+++ b/provisioning/tools-versions.yml
@@ -33,7 +33,6 @@ kubectl_version: 1.27.12
 launchable_version: 1.66.0
 maven_version: 3.9.6
 netlifydeploy_version: 0.1.8
-nodejs_version: 20.11.1
 nodejs_linux_version: 20.11.1
 nodejs_windows_version: 20.11.1
 openssh_authorized_keys_url: https://raw.githubusercontent.com/jenkins-infra/aws/main/ec2_agents_authorized_keys

--- a/provisioning/tools-versions.yml
+++ b/provisioning/tools-versions.yml
@@ -34,6 +34,8 @@ launchable_version: 1.66.0
 maven_version: 3.9.6
 netlifydeploy_version: 0.1.8
 nodejs_version: 20.11.1
+nodejs_linux_version: 20.11.1
+nodejs_windows_version: 20.11.1
 openssh_authorized_keys_url: https://raw.githubusercontent.com/jenkins-infra/aws/main/ec2_agents_authorized_keys
 packer_version: 1.10.2
 python3_version: 3.12.2

--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -636,7 +636,7 @@ function install_nodejs() {
   test -f "${asdf_install_dir}/asdf.sh"
   # Install NodeJS with ASDF and set it as default installation
   install_asdf_plugin nodejs https://github.com/asdf-vm/asdf-nodejs.git
-  install_asdf_package nodejs "${NODEJS_VERSION}"
+  install_asdf_package nodejs "${nodejs_windows_version}"
 
   # Bump NPM to its latest available version
   su - "${username}" -c "source ${asdf_install_dir}/asdf.sh && npm install -g npm"

--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -636,7 +636,7 @@ function install_nodejs() {
   test -f "${asdf_install_dir}/asdf.sh"
   # Install NodeJS with ASDF and set it as default installation
   install_asdf_plugin nodejs https://github.com/asdf-vm/asdf-nodejs.git
-  install_asdf_package nodejs "${nodejs_windows_version}"
+  install_asdf_package nodejs "${NODEJS_WINDOWS_VERSION}"
 
   # Bump NPM to its latest available version
   su - "${username}" -c "source ${asdf_install_dir}/asdf.sh && npm install -g npm"

--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -636,7 +636,7 @@ function install_nodejs() {
   test -f "${asdf_install_dir}/asdf.sh"
   # Install NodeJS with ASDF and set it as default installation
   install_asdf_plugin nodejs https://github.com/asdf-vm/asdf-nodejs.git
-  install_asdf_package nodejs "${NODEJS_WINDOWS_VERSION}"
+  install_asdf_package nodejs "${NODEJS_LINUX_VERSION}"
 
   # Bump NPM to its latest available version
   su - "${username}" -c "source ${asdf_install_dir}/asdf.sh && npm install -g npm"

--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -634,7 +634,7 @@ function install_trivy() {
 function install_nodejs() {
   # Ensure that ASDF is installed
   test -f "${asdf_install_dir}/asdf.sh"
-  # Install NodeJS with ASDF and set it as default installation
+  # Install Node.js with ASDF and set it as default installation
   install_asdf_plugin nodejs https://github.com/asdf-vm/asdf-nodejs.git
   install_asdf_package nodejs "${NODEJS_LINUX_VERSION}"
 

--- a/provisioning/windows-provision.ps1
+++ b/provisioning/windows-provision.ps1
@@ -259,7 +259,7 @@ $downloads = [ordered]@{
             & "choco.exe" install datadog-agent --yes --no-progress --limit-output --fail-on-error-output;
             & "choco.exe" install vcredist2015 --yes --no-progress --limit-output --fail-on-error-output;
             & "choco.exe" install trivy --yes --no-progress --limit-output --fail-on-error-output --version "${env:TRIVY_VERSION}";
-            & "choco.exe" install nodejs.install --yes --no-progress --limit-output --fail-on-error-output --version "${env:NODEJS_VERSION}";
+            & "choco.exe" install nodejs.install --yes --no-progress --limit-output --fail-on-error-output --version "${env:NODEJS_WINDOWS_VERSION}";
             # Installation of python3 for Launchable
             & "choco.exe" install python3 --yes --no-progress --limit-output --fail-on-error-output --version "${env:PYTHON3_VERSION}";
             # Installation of Launchable globally (no other python tool)

--- a/updatecli/updatecli.d/nodejs-linux.yml
+++ b/updatecli/updatecli.d/nodejs-linux.yml
@@ -1,5 +1,5 @@
 ---
-name: Bump NodeJS version
+name: Bump NodeJS version on linux
 
 scms:
   default:
@@ -34,35 +34,30 @@ conditions:
     disablesourceinput: true # Do not pass source as argument to the command line
     spec:
       command: curl --fail --silent --show-error --location --head https://nodejs.org/dist/v{{ source "lastReleaseVersion" }}/node-v{{ source "lastReleaseVersion" }}.tar.gz
-  checkForChocolateyPackage:
-    kind: shell
-    disablesourceinput: true # Do not pass source as argument to the command line
-    spec:
-      command: curl --silent --show-error --location --fail --output /dev/null https://community.chocolatey.org/packages/nodejs.install/{{ source "lastReleaseVersion" }}
 
 targets:
   updateVersion:
-    name: Update the NodeJS version in provisioning environment
+    name: Update the NodeJS version in provisioning environment for linux
     sourceid: lastReleaseVersion
     kind: yaml
     spec:
       file: provisioning/tools-versions.yml
-      key: $.nodejs_version
+      key: $.nodejs_linux_version
     scmid: default
-  updateTestHarness:
+  updateLinuxGossTest:
     name: Update the NodeJS version in the test harness
     sourceid: lastReleaseVersion
     kind: yaml
     spec:
       files:
-        - goss/goss-common.yaml
+        - goss/goss-linux.yaml
       key: $.command.nodejs.stdout[0]
     scmid: default
 
 actions:
   default:
     kind: github/pullrequest
-    title: Bump NodeJS version to {{ source "lastReleaseVersion" }}
+    title: Bump linux NodeJS version to {{ source "lastReleaseVersion" }}
     scmid: default
     spec:
       labels:

--- a/updatecli/updatecli.d/nodejs-linux.yml
+++ b/updatecli/updatecli.d/nodejs-linux.yml
@@ -1,5 +1,5 @@
 ---
-name: Bump NodeJS version on linux
+name: Bump Node.js version on Linux
 
 scms:
   default:
@@ -16,7 +16,7 @@ scms:
 sources:
   lastReleaseVersion:
     kind: githubrelease
-    name: Get the latest NodeJS version
+    name: Get the latest Node.js version
     spec:
       owner: nodejs
       repository: node
@@ -37,7 +37,7 @@ conditions:
 
 targets:
   updateVersion:
-    name: Update the NodeJS version in provisioning environment for linux
+    name: Update Node.js version in provisioning environment for Linux
     sourceid: lastReleaseVersion
     kind: yaml
     spec:
@@ -45,7 +45,7 @@ targets:
       key: $.nodejs_linux_version
     scmid: default
   updateLinuxGossTest:
-    name: Update the NodeJS version in the test harness
+    name: Update Node.js version in the test harness
     sourceid: lastReleaseVersion
     kind: yaml
     spec:
@@ -57,7 +57,7 @@ targets:
 actions:
   default:
     kind: github/pullrequest
-    title: Bump linux NodeJS version to {{ source "lastReleaseVersion" }}
+    title: Bump Node.js version on Linux to {{ source "lastReleaseVersion" }}
     scmid: default
     spec:
       labels:

--- a/updatecli/updatecli.d/nodejs-windows.yml
+++ b/updatecli/updatecli.d/nodejs-windows.yml
@@ -1,0 +1,70 @@
+---
+name: Bump NodeJS version on windows
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastReleaseVersion:
+    kind: githubrelease
+    name: Get the latest NodeJS version
+    spec:
+      owner: nodejs
+      repository: node
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: regex
+        pattern: v20.(\d*).(\d*)
+    transformers:
+      - trimprefix: v
+
+conditions:
+  checkForPackage:
+    kind: shell
+    disablesourceinput: true # Do not pass source as argument to the command line
+    spec:
+      command: curl --fail --silent --show-error --location --head https://nodejs.org/dist/v{{ source "lastReleaseVersion" }}/node-v{{ source "lastReleaseVersion" }}.tar.gz
+  checkForChocolateyPackage:
+    kind: shell
+    disablesourceinput: true # Do not pass source as argument to the command line
+    spec:
+      command: curl --silent --show-error --location --fail --output /dev/null https://community.chocolatey.org/packages/nodejs.install/{{ source "lastReleaseVersion" }}
+
+targets:
+  updateVersion:
+    name: Update the NodeJS version in provisioning environment for windows
+    sourceid: lastReleaseVersion
+    kind: yaml
+    spec:
+      file: provisioning/tools-versions.yml
+      key: $.nodejs_windows_version
+    scmid: default
+  updateWindowsGossTest:
+    name: Update the NodeJS version in the test harness
+    sourceid: lastReleaseVersion
+    kind: yaml
+    spec:
+      files:
+        - goss/goss-windows.yaml
+      key: $.command.nodejs.stdout[0]
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    title: Bump windows NodeJS version to {{ source "lastReleaseVersion" }}
+    scmid: default
+    spec:
+      labels:
+        - enhancement
+        - nodejs

--- a/updatecli/updatecli.d/nodejs-windows.yml
+++ b/updatecli/updatecli.d/nodejs-windows.yml
@@ -1,5 +1,5 @@
 ---
-name: Bump NodeJS version on windows
+name: Bump Node.js version on Windows
 
 scms:
   default:
@@ -42,7 +42,7 @@ conditions:
 
 targets:
   updateVersion:
-    name: Update the NodeJS version in provisioning environment for windows
+    name: Update Node.js version in provisioning environment for Windows
     sourceid: lastReleaseVersion
     kind: yaml
     spec:
@@ -50,7 +50,7 @@ targets:
       key: $.nodejs_windows_version
     scmid: default
   updateWindowsGossTest:
-    name: Update the NodeJS version in the test harness
+    name: Update Node.js version in the test harness
     sourceid: lastReleaseVersion
     kind: yaml
     spec:
@@ -62,7 +62,7 @@ targets:
 actions:
   default:
     kind: github/pullrequest
-    title: Bump windows NodeJS version to {{ source "lastReleaseVersion" }}
+    title: Bump Node.js version on Windows to {{ source "lastReleaseVersion" }}
     scmid: default
     spec:
       labels:

--- a/updatecli/updatecli.d/nodejs-windows.yml
+++ b/updatecli/updatecli.d/nodejs-windows.yml
@@ -49,7 +49,7 @@ targets:
       file: provisioning/tools-versions.yml
       key: $.nodejs_windows_version
     scmid: default
-  updateWindowsGossTest:
+  updateTestHarness:
     name: Update Node.js version in the test harness
     sourceid: lastReleaseVersion
     kind: yaml


### PR DESCRIPTION
as per https://github.com/jenkins-infra/docker-builder/pull/211
we need to upgrade nodejs to 20.12.1 but chocolatey does not provide it.
For now I switch to 2 versions, linux and windows. We will have to choose, if : 
- we remove nodejs from windows if not used
- we change windows nodejs installation to follow the linux versionning


This pull-request once merge will allow updatecli to create a new pull request for linux nodejs