### PR TITLE
chore(goss): add environement variable to goss execution

### DIFF
--- a/build-jenkins-agent-ubuntu.pkr.hcl
+++ b/build-jenkins-agent-ubuntu.pkr.hcl
@@ -57,6 +57,7 @@ build {
 
   provisioner "shell" {
     execute_command = "{{ .Vars }} sudo -E su - jenkins -c \"bash -eu '{{ .Path }}'\""
+    environment_vars  = local.provisioning_env_vars
     inline = [
       "source /home/jenkins/.asdf/asdf.sh", # Required as this is a non-interactive and non-login `bash`
       "goss --version",

--- a/build-jenkins-agent-windows.pkr.hcl
+++ b/build-jenkins-agent-windows.pkr.hcl
@@ -91,6 +91,7 @@ build {
 
   provisioner "powershell" {
     pause_before = "2m" # long pause as 1m is not enough
+    environment_vars  = local.provisioning_env_vars
     inline = [
       "$ErrorActionPreference = 'Stop'",
       "goss --version",


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4090 resolve `executing "test" at <.Env.AGENT_OS_VERSION>: map has no entry for key "AGENT_OS_VERSION"`

