### PR TITLE
hotfix(goss) stop using the `container-structure-test version` until https://github.com/GoogleContainerTools/container-structure-test/issues/445 is resolved

### DIFF
--- a/goss/goss-common.yaml
+++ b/goss/goss-common.yaml
@@ -16,8 +16,9 @@ command:
   container-structure-test:
     exec: container-structure-test version
     exit-status: 0
-    stdout:
-      - 1.18.1
+    ## Commented out until https://github.com/GoogleContainerTools/container-structure-test/issues/445 is resolved
+    # stdout:
+    #   - 1.18.1
   default_java:
     exec: java --version
     exit-status: 0


### PR DESCRIPTION
Builds are failing on Linux and Windows due to this problem: https://github.com/GoogleContainerTools/container-structure-test/issues/445