### PR TITLE
chore(goss): hotfix skip for windows 2019

### DIFF
--- a/goss/goss-windows.yaml
+++ b/goss/goss-windows.yaml
@@ -59,7 +59,7 @@ command:
     exit-status: 0
     stdout:
       - /16\.\d+\.\d+\.\d+/
-    skip: {? {not (eq .Env.AGENT_OS_VERSION "2019"): ''} : ''}
+    skip: {{ not (eq .Env.AGENT_OS_VERSION "2019") }}
 file:
   C:\Program Files\Chromium\Application\:
     contains: []


### PR DESCRIPTION
the PR https://github.com/jenkins-infra/packer-images/pull/1205 altered the skip condition and broke the builds

lets revert the change on skip