### PR TITLE
feat(Windows): add `buildx`

### DIFF
--- a/goss/goss-windows.yaml
+++ b/goss/goss-windows.yaml
@@ -8,6 +8,9 @@ command:
   docker-ce:
     exec: docker -v
     exit-status: 0
+  docker-buildx:
+    exec: docker buildx version
+    exit-status: 0
   jdk11:
     exec: C:\tools\jdk-11\bin\java --version
     exit-status: 0

--- a/provisioning/tools-versions.yml
+++ b/provisioning/tools-versions.yml
@@ -8,6 +8,7 @@ compose_version: 2.27.1
 cst_version: 1.18.1
 default_jdk: 11
 docker_version: 26.1.3
+docker_buildx_version: 0.14.1
 doctl_version: 1.101.0
 gh_version: 2.50.0
 git_lfs_version: 3.5.1

--- a/provisioning/windows-provision.ps1
+++ b/provisioning/windows-provision.ps1
@@ -236,6 +236,10 @@ $downloads = [ordered]@{
         'url' = 'https://github.com/goss-org/goss/releases/download/v{0}/goss-windows-amd64.exe'  -f $env:GOSS_VERSION;
         'local' = "$baseDir\goss.exe"
     };
+    'docker-buildx' = @{
+        'url' = 'https://github.com/docker/buildx/releases/download/v{0}/buildx-v{0}.windows-amd64.exe' -f $env:DOCKER_BUILDX_VERSION;
+        'local' = "C:\ProgramData\docker\cli-plugins\docker-buildx.exe"
+    };
     'chocolatey-and-packages' = @{
         'url' = 'https://github.com/chocolatey/choco/releases/download/{0}/chocolatey.{0}.nupkg' -f $env:CHOCOLATEY_VERSION;
         'local' = "$baseDir\chocolatey.zip";

--- a/provisioning/windows-provision.ps1
+++ b/provisioning/windows-provision.ps1
@@ -79,6 +79,10 @@ New-NetFirewallRule -Name sshd -DisplayName 'OpenSSH Server (sshd)' -Enabled Tru
 $baseDir = 'C:\tools'
 New-Item -ItemType Directory -Path $baseDir -Force | Out-Null
 
+# Special case for docker plugins
+$dockerPluginsDir = 'C:\ProgramData\docker\cli-plugins'
+New-Item -ItemType Directory -Path $dockerPluginsDir -Force | Out-Null
+
 # Ensure NuGet package provider is initialized (non-interactively)
 Get-PackageProvider NuGet -ForceBootstrap
 
@@ -238,7 +242,7 @@ $downloads = [ordered]@{
     };
     'docker-buildx' = @{
         'url' = 'https://github.com/docker/buildx/releases/download/v{0}/buildx-v{0}.windows-amd64.exe' -f $env:DOCKER_BUILDX_VERSION;
-        'local' = "C:\ProgramData\docker\cli-plugins\docker-buildx.exe"
+        'local' = "$dockerPluginsDir\docker-buildx.exe"
     };
     'chocolatey-and-packages' = @{
         'url' = 'https://github.com/chocolatey/choco/releases/download/{0}/chocolatey.{0}.nupkg' -f $env:CHOCOLATEY_VERSION;


### PR DESCRIPTION
This PR adds https://github.com/docker/buildx to the Windows images so we can start using it even if we can't build images yet. (For example `docker buildx bake --print` works)

Related:
- https://github.com/jenkinsci/docker-ssh-agent/pull/415/