### PR TITLE
chore(updatecli) track 1.28.x line of `kubectl` versions

### DIFF
--- a/updatecli/updatecli.d/kubectl.yaml
+++ b/updatecli/updatecli.d/kubectl.yaml
@@ -26,7 +26,7 @@ sources:
       username: "{{ .github.username }}"
       versionfilter:
         kind: regex
-        pattern: "^kubernetes-1.27.(\\d*)$"
+        pattern: "^kubernetes-1.28.(\\d*)$"
 
 targets:
   updateVersion:


### PR DESCRIPTION
As per [#4144](https://github.com/jenkins-infra/helpdesk/issues/4144) this PR updates updatecli manifest to track  1.28.x line of kubectl versions.