### PR TITLE
chore(updatecli) fix az CLI manifest to only get the latest GH release

### DIFF
--- a/updatecli/updatecli.d/azure-cli.yml
+++ b/updatecli/updatecli.d/azure-cli.yml
@@ -22,12 +22,10 @@ sources:
       repository: "azure-cli"
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
-      versionfilter:
-        kind: regex
-        ## Latest stable x.y.z version
-        pattern: 'azure-cli-(\d*)\.(\d*)\.(\d*)$'
+      typefilter:
+        latest: true
     transformers:
-      - trimprefix: "azure-cli-"
+      - trimprefix: 'azure-cli-'
 
 targets:
   updateVersion:


### PR DESCRIPTION
Closes #1246 