### PR TITLE
chore(updatecli): update datadog gpg key and re-enable `doctl` manifest

### DIFF
--- a/updatecli/updatecli.d/datadog-gpg-key.yaml
+++ b/updatecli/updatecli.d/datadog-gpg-key.yaml
@@ -1,5 +1,5 @@
 ---
-name: Bump `DATADOG GPG KEY`
+name: Bump Datadog GPG public key
 
 scms:
   default:
@@ -16,13 +16,14 @@ scms:
 sources:
   lastGPGkey:
     kind: file
-    name: Get the latest `DATADOG GPG KEY`
+    name: Get the latest Datadog GPG public key
     spec:
       file: https://keys.datadoghq.com/DATADOG_APT_KEY_CURRENT.public
 targets:
   updateGPGdatadog:
-    name: "Update the `DATADOG GPG KEY` in the local gpg file"
+    name: "Update the Datadog GPG public key in the local gpg file"
     sourceid: lastGPGkey
+    scmid: default
     kind: file
     spec:
       file: gpg-keys/datadog.gpg
@@ -30,8 +31,8 @@ targets:
 actions:
   default:
     kind: github/pullrequest
-    title: Bump `DATADOG GPG KEY`
     scmid: default
+    title: Bump Datadog GPG public key
     spec:
       labels:
         - enhancement

--- a/updatecli/updatecli.d/datadog-gpg-key.yaml
+++ b/updatecli/updatecli.d/datadog-gpg-key.yaml
@@ -1,0 +1,38 @@
+---
+name: Bump `DATADOG GPG KEY`
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastGPGkey:
+    kind: file
+    name: Get the latest `DATADOG GPG KEY`
+    spec:
+      file: https://keys.datadoghq.com/DATADOG_APT_KEY_CURRENT.public
+targets:
+  updateGPGdatadog:
+    name: "Update the `DATADOG GPG KEY` in the local gpg file"
+    sourceid: lastGPGkey
+    kind: file
+    spec:
+      file: gpg-keys/datadog.gpg
+
+actions:
+  default:
+    kind: github/pullrequest
+    title: Bump `DATADOG GPG KEY`
+    scmid: default
+    spec:
+      labels:
+        - enhancement
+        - datadog

--- a/updatecli/updatecli.d/doctl.yaml
+++ b/updatecli/updatecli.d/doctl.yaml
@@ -33,14 +33,14 @@ targets:
     spec:
       file: provisioning/tools-versions.yml
       key: $.doctl_version
-    # scmid: default
+    scmid: default
   updateVersionInGoss:
     name: Update the `DOCTL` version in the goss test
     kind: yaml
     spec:
       file: goss/goss-linux.yaml
       key: $.command.doctl.stdout[0]
-    # scmid: default
+    scmid: default
 
 actions:
   default:


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4178
keep updated the datadog gpg key 

also re-enable updatecli for DOCTL