### PR TITLE
chore(updatecli): Track 1.29x line of kubectl versions

### DIFF
--- a/updatecli/updatecli.d/kubectl.yaml
+++ b/updatecli/updatecli.d/kubectl.yaml
@@ -26,7 +26,7 @@ sources:
       username: "{{ .github.username }}"
       versionfilter:
         kind: regex
-        pattern: "^kubernetes-1.28.(\\d*)$"
+        pattern: "^kubernetes-1.29.(\\d*)$"
 
 targets:
   updateVersion:


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/4161#issuecomment-2299149540

updatecli set to track kub 1.29x versions.