### PR TITLE
chore(updatecli) use Jenkins ATH as source for maven version

### DIFF
--- a/updatecli/updatecli.d/maven.yml
+++ b/updatecli/updatecli.d/maven.yml
@@ -15,19 +15,16 @@ scms:
 
 sources:
   mavenVersion:
-    kind: githubrelease
-    name: Get the latest Maven version
+    # Using a file with a transformer until https://github.com/updatecli/updatecli/issues/2275 is done
+    kind: file
+    name: Get the latest Maven version use on the principal branch of the Jenkins ATH
     spec:
-      owner: "apache"
-      repository: "maven"
-      token: "{{ requiredEnv .github.token }}"
-      username: "{{ .github.username }}"
-      versionfilter:
-        kind: regex
-        # Only full releases (semver with "maven-" prefix")
-        pattern: "^maven-(\\d*).(\\d*).(\\d*)$"
+      file: https://raw.githubusercontent.com/jenkinsci/acceptance-test-harness/master/src/main/resources/ath-container/Dockerfile
+      matchpattern: 'ARG MAVEN_VERSION=.*'
     transformers:
-      - trimprefix: "maven-"
+      - findsubmatch:
+          pattern: 'ARG MAVEN_VERSION=(.*)'
+          captureindex: 1
 
 conditions:
   checkIfReleaseIsAvailable:


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/4249#issuecomment-2301857110

We want to make sure there is at least a "real life" smoke test of a new Maven version before rollout.

- We will now rely on the ATH to be up to date which is acceptable
- IF a new Maven version is required, we can always update by hand


cc @MarkEWaite for info