### PR TITLE
feat!(ubuntu): Removed all definitions of 'default_jdk' from ubuntu image templates

### DIFF
--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -340,11 +340,6 @@ function download_temurin_jdk() {
   mkdir -p "${installation_dir}"
   tar --extract --gunzip --file="${temp_archive}" --directory="${installation_dir}" --strip-components=1
 
-  # Define JDK installations
-  # The priority of a JDK is the last argument.
-  # Starts by setting priority to the JDK major version: higher version is the expected default
-  update-alternatives --install /usr/bin/java java "${installation_dir}"/bin/java "${major_jdk_version}"
-
   rm -f "${temp_archive}"
 }
 
@@ -359,10 +354,6 @@ function install_jdks() {
     download_temurin_jdk "${jdk_version_to_install}"
     echo "=== Installation of Temurin JDK version ${jdk_version_to_install} done."
   done
-
-  # Use the DEFAULT_JDK env var to set the priority of the specified default JDK to 1000 to ensure its the one used by update-alternatives
-  update-alternatives --install /usr/bin/java java "/opt/jdk-${DEFAULT_JDK}/bin/java" 1000
-  echo "JAVA_HOME=/opt/jdk-${DEFAULT_JDK}" >> /etc/environment
 }
 
 ## Ensure that docker-compose is installed (version from environment)

--- a/tests/goss-common.yaml
+++ b/tests/goss-common.yaml
@@ -27,11 +27,6 @@ command:
   docker_buildx:
     exec: docker buildx version
     exit-status: 0
-  default_java:
-    exec: java --version
-    exit-status: 0
-    stdout:
-      - 11.0.24+8
   docker_compose:
     exec: docker-compose -v
     exit-status: 0

--- a/tests/goss-common.yaml
+++ b/tests/goss-common.yaml
@@ -27,6 +27,10 @@ command:
   docker_buildx:
     exec: docker buildx version
     exit-status: 0
+  default_java:
+    exec: java --version
+    exit-status:
+      not: 0
   docker_compose:
     exec: docker-compose -v
     exit-status: 0

--- a/tests/goss-common.yaml
+++ b/tests/goss-common.yaml
@@ -27,10 +27,6 @@ command:
   docker_buildx:
     exec: docker buildx version
     exit-status: 0
-  default_java:
-    exec: java --version
-    exit-status:
-      not: 0
   docker_compose:
     exec: docker-compose -v
     exit-status: 0

--- a/tests/goss-linux.yaml
+++ b/tests/goss-linux.yaml
@@ -17,6 +17,9 @@ command:
   datadog-agent:
     exec: datadog-agent version
     exit-status: 0
+  default_java:
+    exec: java --version
+    exit-status: 0
   doctl:
     exec: doctl version
     exit-status: 0
@@ -75,7 +78,7 @@ command:
     stderr:
       - 1.8.0_422
   maven:
-    exec: mvn -v
+    exec: JAVA_HOME=/opt/jdk-21 mvn -v
     exit-status: 0
     stdout:
       - 3.9.9

--- a/tests/goss-linux.yaml
+++ b/tests/goss-linux.yaml
@@ -17,9 +17,6 @@ command:
   datadog-agent:
     exec: datadog-agent version
     exit-status: 0
-  default_java:
-    exec: java --version
-    exit-status: 0
   doctl:
     exec: doctl version
     exit-status: 0

--- a/tests/goss-linux.yaml
+++ b/tests/goss-linux.yaml
@@ -17,6 +17,10 @@ command:
   datadog-agent:
     exec: datadog-agent version
     exit-status: 0
+  default_java:
+    exec: java --version
+    exit-status:
+      not: 0
   doctl:
     exec: doctl version
     exit-status: 0

--- a/tests/goss-windows.yaml
+++ b/tests/goss-windows.yaml
@@ -13,6 +13,8 @@ command:
   default_java:
     exec: java --version
     exit-status: 0
+    stdout:
+      - 11.0.24+8
   jdk11:
     exec: C:\tools\jdk-11\bin\java --version
     exit-status: 0

--- a/tests/goss-windows.yaml
+++ b/tests/goss-windows.yaml
@@ -10,6 +10,9 @@ command:
   docker-buildx:
     exec: docker buildx version
     exit-status: 0
+  default_java:
+    exec: java --version
+    exit-status: 0
   jdk11:
     exec: C:\tools\jdk-11\bin\java --version
     exit-status: 0


### PR DESCRIPTION
BREAKING CHANGE: removing the default_jdk env variable will introduce failure in goss tess harness for windows and might result in build failures.

As per https://github.com/jenkins-infra/helpdesk/issues/4124#issuecomment-2307122480 :

Any definition of a 'default JDK' and 'update-alternatives' on the jenkins-infra/packer-images has been removed from the ubuntu-provisioning script.  The corresponding goss test patch has also been added to the goss test harness to check installation of maven.