### PR TITLE
Revert "Bump Docker CE version to 27.2.0"

### DIFF
--- a/provisioning/tools-versions.yml
+++ b/provisioning/tools-versions.yml
@@ -7,7 +7,7 @@ chocolatey_version: 1.4.0
 compose_version: 2.29.2
 cst_version: 1.19.1
 default_jdk: 11
-docker_version: 27.2.0
+docker_version: 27.1.2
 docker_buildx_version: 0.14.1
 doctl_version: 1.111.0
 gh_version: 2.55.0

--- a/tests/goss-common.yaml
+++ b/tests/goss-common.yaml
@@ -23,7 +23,7 @@ command:
     exec: docker -v
     exit-status: 0
     stdout:
-      - 27.2.0
+      - 27.1.2
   docker_buildx:
     exec: docker buildx version
     exit-status: 0


### PR DESCRIPTION
Reverts jenkins-infra/packer-images#1369

We see `docker login` steps failing: 27.2.1 should fix this (https://github.com/docker/cli/pull/5380) though