### PR TITLE
feat!(windows): Removed all definitions of 'default_jdk' from windows image templates

### DIFF
--- a/provisioning/tools-versions.yml
+++ b/provisioning/tools-versions.yml
@@ -6,7 +6,6 @@ azurecli_version: 2.64.0
 chocolatey_version: 1.4.0
 compose_version: 2.29.2
 cst_version: 1.19.1
-default_jdk: 11
 docker_version: 27.1.2
 docker_buildx_version: 0.14.1
 doctl_version: 1.111.0

--- a/provisioning/windows-provision.ps1
+++ b/provisioning/windows-provision.ps1
@@ -294,15 +294,6 @@ if("2019" -eq $env:AGENT_OS_VERSION) {
 ## Add tools folder to PATH so we can sanity check them as soon as they are installed
 AddToPathEnv $baseDir
 
-## Sets the default JDK
-$defaultJavaHome = '{0}\jdk-{1}' -f $baseDir,$env:DEFAULT_JDK
-$defaultJavaBinPath = '{0}\bin' -f $defaultJavaHome
-AddToPathEnv $defaultJavaBinPath
-# env JAVA_HOME
-New-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name 'JAVA_HOME' -Value $defaultJavaHome | Out-Null
-## Maven requires the JAVA_HOME environment variable to be set. We use this value here: it is ephemeral.
-$env:JAVA_HOME = $defaultJavaHome
-
 ## Proceed to install tools
 # TODO: foreach in parallel for downloads
 foreach($k in $downloads.Keys) {

--- a/tests/goss-common.yaml
+++ b/tests/goss-common.yaml
@@ -27,6 +27,10 @@ command:
   docker_buildx:
     exec: docker buildx version
     exit-status: 0
+  default_java:
+    exec: java --version
+    exit-status:
+      not: 0
   docker_compose:
     exec: docker-compose -v
     exit-status: 0

--- a/tests/goss-common.yaml
+++ b/tests/goss-common.yaml
@@ -27,10 +27,6 @@ command:
   docker_buildx:
     exec: docker buildx version
     exit-status: 0
-  default_java:
-    exec: java --version
-    exit-status:
-      not: 0
   docker_compose:
     exec: docker-compose -v
     exit-status: 0

--- a/tests/goss-linux.yaml
+++ b/tests/goss-linux.yaml
@@ -17,10 +17,6 @@ command:
   datadog-agent:
     exec: datadog-agent version
     exit-status: 0
-  default_java:
-    exec: java --version
-    exit-status:
-      not: 0
   doctl:
     exec: doctl version
     exit-status: 0

--- a/tests/goss-windows-2019.yaml
+++ b/tests/goss-windows-2019.yaml
@@ -9,8 +9,3 @@ command:
     exit-status: 0
     stdout:
       - /16\.\d+\.\d+\.\d+/
-  maven:
-    exec: powershell "$env:JAVA_HOME='C:\\Program Files (x86)\\jdk-21'; mvn -v"
-    exit-status: 0
-    stdout:
-      - '/3\.9\.9/'

--- a/tests/goss-windows-2019.yaml
+++ b/tests/goss-windows-2019.yaml
@@ -10,7 +10,7 @@ command:
     stdout:
       - /16\.\d+\.\d+\.\d+/
   maven:
-  exec: powershell "$env:JAVA_HOME='C:\\Program Files (x86)\\jdk-21'; mvn -v"
+    exec: powershell "$env:JAVA_HOME='C:\\Program Files (x86)\\jdk-21'; mvn -v"
     exit-status: 0
     stdout:
       - '/3\.9\.9/'

--- a/tests/goss-windows-2019.yaml
+++ b/tests/goss-windows-2019.yaml
@@ -9,3 +9,8 @@ command:
     exit-status: 0
     stdout:
       - /16\.\d+\.\d+\.\d+/
+  maven:
+  exec: powershell "$env:JAVA_HOME='C:\\Program Files (x86)\\jdk-21'; mvn -v"
+    exit-status: 0
+    stdout:
+      - '/3\.9\.9/'

--- a/tests/goss-windows.yaml
+++ b/tests/goss-windows.yaml
@@ -10,11 +10,6 @@ command:
   docker-buildx:
     exec: docker buildx version
     exit-status: 0
-  default_java:
-    exec: java --version
-    exit-status: 0
-    stdout:
-      - 11.0.24+8
   jdk11:
     exec: C:\tools\jdk-11\bin\java --version
     exit-status: 0
@@ -35,6 +30,11 @@ command:
     exit-status: 0
     stderr:
       - 1.8.0_422
+  maven:
+    exec: pwsh -command "$env:JAVA_HOME='C:\\Program Files (x86)\\jdk-21'; mvn -v"
+    exit-status: 0
+    stdout:
+      - 3.9.9
   nodejs:
     exec: node --version
     exit-status: 0

--- a/updatecli/updatecli.d/jdk11.yml
+++ b/updatecli/updatecli.d/jdk11.yml
@@ -56,14 +56,6 @@ targets:
         - tests/goss-windows.yaml
       key: $.command.jdk11.stdout[0]
     scmid: default
-  updateDefaultJDKVersionInGoss:
-    name: Update the default Java version in the goss tests
-    kind: yaml
-    spec:
-      files:
-        - tests/goss-common.yaml
-      key: $.command.default_java.stdout[0]
-    scmid: default
 
 actions:
   default:


### PR DESCRIPTION
BREAKING CHANGE: removing the default_jdk env variable will introduce failure in goss tess harness.

As per https://github.com/jenkins-infra/helpdesk/issues/4124#issuecomment-2307122480 :

Any definition of a 'default JDK' on the jenkins-infra/packer-images has been removed from the windows-provisioning script. The corresponding goss test patch has also been added to the goss test harness to check installation of maven.