### PR TITLE
chore(updatecli):retrieve Maven version from the source with a native resource(dockerfile)

### DIFF
--- a/updatecli/updatecli.d/maven.yml
+++ b/updatecli/updatecli.d/maven.yml
@@ -15,16 +15,13 @@ scms:
 
 sources:
   mavenVersion:
-    # Using a file with a transformer until https://github.com/updatecli/updatecli/issues/2275 is done
-    kind: file
+    kind: dockerfile
     name: Get the latest Maven version use on the principal branch of the Jenkins ATH
     spec:
       file: https://raw.githubusercontent.com/jenkinsci/acceptance-test-harness/master/src/main/resources/ath-container/Dockerfile
-      matchpattern: 'ARG MAVEN_VERSION=.*'
-    transformers:
-      - findsubmatch:
-          pattern: 'ARG MAVEN_VERSION=(.*)'
-          captureindex: 1
+      instruction:
+        keyword: "ARG"
+        matcher: "MAVEN_VERSION"
 
 conditions:
   checkIfReleaseIsAvailable:


### PR DESCRIPTION
As per https://github.com/jenkins-infra/packer-images/issues/1381#issue-2507739764

We switch to the new source of type dockerfile which is easier to read and maintain.

Tested and successful locally.

Also related ( https://github.com/jenkins-infra/helpdesk/issues/4280 )
