### PR TITLE
feat(ubuntu): Introducing entropy tools in ubuntu VM templates

### DIFF
--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -675,19 +675,17 @@ function cleanup() {
 ## Install rngd to increase VM entropy
 function install_rngd() {
   apt-get update --quiet
-  apt-get install --yes --no-install-recommends rng-tools-debian
-  systemctl daemon-reload
-  systemctl enable rng-tools-debian
-  systemctl start rng-tools-debian
+  apt-get install --yes --no-install-recommends rng-tools5
+  systemctl enable rng-tools5 || true
+  systemctl rng-tools5 || true
 }
 
 ## Install havegd to increase VM entropy
 function install_haveged() {
   apt-get update --quiet
   apt-get install --yes --no-install-recommends haveged
-  systemctl daemon-reload
-  systemctl enable haveged
-  systemctl start haveged
+  systemctl enable haveged || true
+  systemctl start haveged || true
 }
 
 function main() {

--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -677,7 +677,7 @@ function install_rngd() {
   apt-get update --quiet
   apt-get install --yes --no-install-recommends rng-tools5
   systemctl enable rng-tools5 || true # Uses logical operator '|| true' to prevent script from failing due to non-zero exit status in the case of docker containers
-  systemctl rng-tools5 || true
+  systemctl start rngd || true
 }
 
 ## Install havegd to increase VM entropy

--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -676,7 +676,7 @@ function cleanup() {
 function install_rngd() {
   apt-get update --quiet
   apt-get install --yes --no-install-recommends rng-tools5
-  systemctl enable rng-tools5 || true
+  systemctl enable rng-tools5 || true # Uses logical operator '|| true' to prevent script from failing due to non-zero exit status in the case of docker containers
   systemctl rng-tools5 || true
 }
 
@@ -684,7 +684,7 @@ function install_rngd() {
 function install_haveged() {
   apt-get update --quiet
   apt-get install --yes --no-install-recommends haveged
-  systemctl enable haveged || true
+  systemctl enable haveged || true # Uses logical operator '|| true' to prevent script from failing due to non-zero exit status in the case of docker containers
   systemctl start haveged || true
 }
 

--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -672,6 +672,24 @@ function cleanup() {
   sync
 }
 
+## Install rngd to increase VM entropy
+function install_rngd() {
+  apt-get update --quiet
+  apt-get install --yes --no-install-recommends rng-tools-debian
+  systemctl daemon-reload
+  systemctl enable rng-tools-debian
+  systemctl start rng-tools-debian
+}
+
+## Install havegd to increase VM entropy
+function install_haveged() {
+  apt-get update --quiet
+  apt-get install --yes --no-install-recommends haveged
+  systemctl daemon-reload
+  systemctl enable haveged
+  systemctl start haveged
+}
+
 function main() {
   check_commands
   copy_custom_scripts
@@ -720,6 +738,8 @@ function main() {
   install_helmfile
   install_sops
   install_yamllint
+  install_rngd
+  install_haveged
 
   echo "== Installed packages:"
   dpkg -l

--- a/tests/goss-linux.yaml
+++ b/tests/goss-linux.yaml
@@ -37,6 +37,9 @@ command:
     exit-status: 0
     stdout:
       - 1.55.2
+  haveged:
+    exec: haveged --version
+    exit-status: 0
   helm:
     exec: helm version
     exit-status: 0
@@ -103,6 +106,9 @@ command:
     stdout:
       - 2.6.10
       - 3.3.5
+  rngd:
+    exec: rngd --version
+    exit-status: 0
   sops:
     exec: sops --version
     exit-status: 0


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/4281#issue-2507657045

Linux VM agents have entropy tools `rngd` and `haveged` installed and enabled at boot time.

Goss text contract to ensure installation of both tools has also been included in this PR.