### PR TITLE
feat(ubuntu):Removed haveged installation and goss test

### DIFF
--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -680,14 +680,6 @@ function install_rngd() {
   systemctl start rngd || true
 }
 
-## Install havegd to increase VM entropy
-function install_haveged() {
-  apt-get update --quiet
-  apt-get install --yes --no-install-recommends haveged
-  systemctl enable haveged || true # Uses logical operator '|| true' to prevent script from failing due to non-zero exit status in the case of docker containers
-  systemctl start haveged || true
-}
-
 function main() {
   check_commands
   copy_custom_scripts
@@ -737,7 +729,6 @@ function main() {
   install_sops
   install_yamllint
   install_rngd
-  install_haveged
 
   echo "== Installed packages:"
   dpkg -l

--- a/tests/goss-linux.yaml
+++ b/tests/goss-linux.yaml
@@ -37,9 +37,6 @@ command:
     exit-status: 0
     stdout:
       - 1.55.2
-  haveged:
-    exec: haveged --version
-    exit-status: 0
   helm:
     exec: helm version
     exit-status: 0


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/4281#issuecomment-2381344015

This PR removes installation of `haveged` tool on our Linux VM agents since `rngd` produces enough entropy as per our requirements.