### PR TITLE
chore(updatecli): add manifest for azure windows images

### DIFF
--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -1,5 +1,7 @@
-if (env.BRANCH_IS_PRIMARY) {
-    updatecli(action: 'apply', updatecliAgentLabel: 'linux-amd64-docker', cronTriggerExpression: '@daily')
-} else {
-    updatecli(action: 'diff', updatecliAgentLabel: 'linux-amd64-docker')
+withCredentials([azureServicePrincipal('packer-azure-serviceprincipal-sponsorship')]) {
+    if (env.BRANCH_IS_PRIMARY) {
+        updatecli(action: 'apply', updatecliAgentLabel: 'linux-amd64-docker', cronTriggerExpression: '@daily')
+    } else {
+        updatecli(action: 'diff', updatecliAgentLabel: 'linux-amd64-docker')
+    }
 }

--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -1,4 +1,4 @@
-withCredentials([azureServicePrincipal('packer-azure-serviceprincipal-sponsorship')]) {
+withCredentials([azureServicePrincipal('updatecli-azure-serviceprincipal')]) {
     if (env.BRANCH_IS_PRIMARY) {
         updatecli(action: 'apply', updatecliAgentLabel: 'linux-amd64-docker', cronTriggerExpression: '@daily')
     } else {

--- a/build-jenkins-agent-windows.pkr.hcl
+++ b/build-jenkins-agent-windows.pkr.hcl
@@ -7,7 +7,7 @@ build {
     image_publisher = "MicrosoftWindowsServer"
     # List available SKUs with the command `az vm image list-skus --offer WindowsServer --location eastus --publisher MicrosoftWindowsServer --output table`
     image_sku       = "${var.agent_os_version}-datacenter-core-g2"
-    image_version   = local.images_versions["azure"]["windows"][var.agent_os_version][var.architecture]
+    image_version   = lookup(local.images_versions["azure"]["windows"],[var.agent_os_version][var.architecture], "N/A")
     os_type         = "Windows"
     os_disk_size_gb = local.windows_disk_size_gb
     winrm_insecure  = true

--- a/build-jenkins-agent-windows.pkr.hcl
+++ b/build-jenkins-agent-windows.pkr.hcl
@@ -7,7 +7,7 @@ build {
     image_publisher = "MicrosoftWindowsServer"
     # List available SKUs with the command `az vm image list-skus --offer WindowsServer --location eastus --publisher MicrosoftWindowsServer --output table`
     image_sku       = "${var.agent_os_version}-datacenter-core-g2"
-    image_version   = local.images_versions.windows[var.agent_os_version][var.architecture]
+    image_version   = local.images_versions["windows"][var.agent_os_version][var.architecture]
     os_type         = "Windows"
     os_disk_size_gb = local.windows_disk_size_gb
     winrm_insecure  = true

--- a/build-jenkins-agent-windows.pkr.hcl
+++ b/build-jenkins-agent-windows.pkr.hcl
@@ -7,7 +7,7 @@ build {
     image_publisher = "MicrosoftWindowsServer"
     # List available SKUs with the command `az vm image list-skus --offer WindowsServer --location eastus --publisher MicrosoftWindowsServer --output table`
     image_sku       = "${var.agent_os_version}-datacenter-core-g2"
-    image_version   = local.windows_image_version[var.agent_os_version]
+    image_version   = local.images_versions.windows[var.agent_os_version][var.architecture]
     os_type         = "Windows"
     os_disk_size_gb = local.windows_disk_size_gb
     winrm_insecure  = true

--- a/build-jenkins-agent-windows.pkr.hcl
+++ b/build-jenkins-agent-windows.pkr.hcl
@@ -7,8 +7,6 @@ build {
     image_publisher = "MicrosoftWindowsServer"
     # List available SKUs with the command `az vm image list-skus --offer WindowsServer --location eastus --publisher MicrosoftWindowsServer --output table`
     image_sku       = "${var.agent_os_version}-datacenter-core-g2"
-    #image_version   = local.images_versions["azure"]["windows"][var.agent_os_version][var.architecture]
-    #image_version   = lookup(local.images_versions["azure"]["windows"],var.agent_os_version, {"amd64"="N/A", "arm64"="N/A"})[var.architecture]
     image_version   = try(local.images_versions["azure"]["windows"][var.agent_os_version][var.architecture], "N/A")
     os_type         = "Windows"
     os_disk_size_gb = local.windows_disk_size_gb

--- a/build-jenkins-agent-windows.pkr.hcl
+++ b/build-jenkins-agent-windows.pkr.hcl
@@ -8,7 +8,8 @@ build {
     # List available SKUs with the command `az vm image list-skus --offer WindowsServer --location eastus --publisher MicrosoftWindowsServer --output table`
     image_sku       = "${var.agent_os_version}-datacenter-core-g2"
     #image_version   = local.images_versions["azure"]["windows"][var.agent_os_version][var.architecture]
-    image_version   = lookup(local.images_versions["azure"]["windows"],var.agent_os_version, {"amd64"="N/A", "arm64"="N/A"})[var.architecture]
+    #image_version   = lookup(local.images_versions["azure"]["windows"],var.agent_os_version, {"amd64"="N/A", "arm64"="N/A"})[var.architecture]
+    image_version   = try(local.images_versions["azure"]["windows"][var.agent_os_version][var.architecture], "N/A")
     os_type         = "Windows"
     os_disk_size_gb = local.windows_disk_size_gb
     winrm_insecure  = true

--- a/build-jenkins-agent-windows.pkr.hcl
+++ b/build-jenkins-agent-windows.pkr.hcl
@@ -7,7 +7,8 @@ build {
     image_publisher = "MicrosoftWindowsServer"
     # List available SKUs with the command `az vm image list-skus --offer WindowsServer --location eastus --publisher MicrosoftWindowsServer --output table`
     image_sku       = "${var.agent_os_version}-datacenter-core-g2"
-    image_version   = lookup(local.images_versions["azure"]["windows"],[var.agent_os_version], {arm64="N/A", amd64="N/A"})[var.architecture]
+    #image_version   = local.images_versions["azure"]["windows"][var.agent_os_version][var.architecture]
+    image_version   = lookup(local.images_versions["azure"]["windows"],var.agent_os_version, {"amd64"="N/A", "arm64"="N/A"})[var.architecture]
     os_type         = "Windows"
     os_disk_size_gb = local.windows_disk_size_gb
     winrm_insecure  = true

--- a/build-jenkins-agent-windows.pkr.hcl
+++ b/build-jenkins-agent-windows.pkr.hcl
@@ -7,7 +7,7 @@ build {
     image_publisher = "MicrosoftWindowsServer"
     # List available SKUs with the command `az vm image list-skus --offer WindowsServer --location eastus --publisher MicrosoftWindowsServer --output table`
     image_sku       = "${var.agent_os_version}-datacenter-core-g2"
-    image_version   = local.images_versions["windows"][var.agent_os_version][var.architecture]
+    image_version   = local.images_versions["azure"]["windows"][var.agent_os_version][var.architecture]
     os_type         = "Windows"
     os_disk_size_gb = local.windows_disk_size_gb
     winrm_insecure  = true

--- a/build-jenkins-agent-windows.pkr.hcl
+++ b/build-jenkins-agent-windows.pkr.hcl
@@ -7,7 +7,7 @@ build {
     image_publisher = "MicrosoftWindowsServer"
     # List available SKUs with the command `az vm image list-skus --offer WindowsServer --location eastus --publisher MicrosoftWindowsServer --output table`
     image_sku       = "${var.agent_os_version}-datacenter-core-g2"
-    image_version   = lookup(local.images_versions["azure"]["windows"][var.agent_os_version],[var.architecture], "N/A")
+    image_version   = lookup(local.images_versions["azure"]["windows"],[var.agent_os_version], {arm64="N/A", amd64="N/A"})[var.architecture]
     os_type         = "Windows"
     os_disk_size_gb = local.windows_disk_size_gb
     winrm_insecure  = true

--- a/build-jenkins-agent-windows.pkr.hcl
+++ b/build-jenkins-agent-windows.pkr.hcl
@@ -7,7 +7,7 @@ build {
     image_publisher = "MicrosoftWindowsServer"
     # List available SKUs with the command `az vm image list-skus --offer WindowsServer --location eastus --publisher MicrosoftWindowsServer --output table`
     image_sku       = "${var.agent_os_version}-datacenter-core-g2"
-    image_version   = lookup(local.images_versions["azure"]["windows"],[var.agent_os_version][var.architecture], "N/A")
+    image_version   = lookup(local.images_versions["azure"]["windows"][var.agent_os_version],[var.architecture], "N/A")
     os_type         = "Windows"
     os_disk_size_gb = local.windows_disk_size_gb
     winrm_insecure  = true

--- a/images-versions.yaml
+++ b/images-versions.yaml
@@ -1,6 +1,17 @@
 # images-versions.yaml
 ---
-windows_image_version:
-  2019: "17763.6293.240905"
-  2022: "20348.2762.241006"
-  "22.04": "latest" #just to avoid error on run for linux, but not used
+azure:
+  windows:
+    "2019":
+      amd64: "17763.6293.240905"
+    "2022":
+      amd64: "20348.2762.241006"
+  ubuntu:
+    "22.04":
+      amd64: "latest"
+      arm64: "latest"
+aws:
+  ubuntu:
+    "22.04":
+      amd64: ami-00eb69d236edcfaf8
+      arm64: ami-039e419d24a37cb82

--- a/images-versions.yaml
+++ b/images-versions.yaml
@@ -1,0 +1,6 @@
+# images-versions.yaml
+---
+windows_image_version:
+  2019: "17763.6293.240905"
+  2022: "20348.2762.241006"
+  "22.04": "latest" #just to avoid error on run for linux, but not used

--- a/locals.pkr.hcl
+++ b/locals.pkr.hcl
@@ -28,11 +28,7 @@ locals {
   }
 
   # List available images `az vm image list --location eastus --publisher MicrosoftWindowsServer --offer WindowsServer --sku 2022-datacenter-core-g2 --all --output table`
-  windows_image_version = {
-    "2019"  = "17763.6293.240905"
-    "2022"  = "20348.2762.241006"
-    "22.04" = "latest" #just to avoid error on run for linux, but not used
-  }
+  windows_image_version = yamldecode(file("${path.module}/packer-versions.yaml")).windows_image_version
 
   azure_vm_size = {
     "amd64" = "Standard_D4ads_v5" # 4 CPU / 16 GB / Huge size required to avoid https:#docs.microsoft.com/en-us/azure/virtual-machines/linux/image-builder-troubleshoot#sysprep-timing and avoid full disk (DS2v2 only have 14 Gb SSD for system)

--- a/locals.pkr.hcl
+++ b/locals.pkr.hcl
@@ -27,7 +27,7 @@ locals {
     "amazon-ebs" = "Administrator"
   }
 
-  images_versions = yamldecode(file("${path.module}/images-versions.yaml"))
+  images_versions = yamldecode(file("./images-versions.yaml"))
 
   azure_vm_size = {
     "amd64" = "Standard_D4ads_v5" # 4 CPU / 16 GB / Huge size required to avoid https:#docs.microsoft.com/en-us/azure/virtual-machines/linux/image-builder-troubleshoot#sysprep-timing and avoid full disk (DS2v2 only have 14 Gb SSD for system)

--- a/locals.pkr.hcl
+++ b/locals.pkr.hcl
@@ -27,8 +27,7 @@ locals {
     "amazon-ebs" = "Administrator"
   }
 
-  # List available images `az vm image list --location eastus --publisher MicrosoftWindowsServer --offer WindowsServer --sku 2022-datacenter-core-g2 --all --output table`
-  windows_image_version = yamldecode(file("${path.module}/packer-versions.yaml")).windows_image_version
+  images_versions = yamldecode(file("${path.module}/images-versions.yaml"))
 
   azure_vm_size = {
     "amd64" = "Standard_D4ads_v5" # 4 CPU / 16 GB / Huge size required to avoid https:#docs.microsoft.com/en-us/azure/virtual-machines/linux/image-builder-troubleshoot#sysprep-timing and avoid full disk (DS2v2 only have 14 Gb SSD for system)

--- a/updatecli/updatecli.d/windows-2019-images.yml
+++ b/updatecli/updatecli.d/windows-2019-images.yml
@@ -20,7 +20,7 @@ sources:
     spec:
       environments:
         - name: PATH
-      command: az vm image list --location eastus --publisher MicrosoftWindowsServer --offer WindowsServer --sku 2019-datacenter-core-g2 --all --query "[?offer=='WindowsServer'].version" -o tsv | sort -u | tail -n 1
+      command: az login --service-principal -u "$PACKER_AZURE_CLIENT_ID" -p "$PACKER_AZURE_CLIENT_SECRET" -t "$PACKER_AZURE_TENANT_ID" && az vm image list --location eastus --publisher MicrosoftWindowsServer --offer WindowsServer --sku 2019-datacenter-core-g2 --all --query "[?offer=='WindowsServer'].version" -o tsv | sort -u | tail -n 1
 
 conditions:
   checkifazcommandwork:
@@ -29,7 +29,7 @@ conditions:
     spec:
       environments:
         - name: PATH
-      command: az account show --output none
+      command: az login --service-principal -u "$PACKER_AZURE_CLIENT_ID" -p "$PACKER_AZURE_CLIENT_SECRET" -t "$PACKER_AZURE_TENANT_ID" && az account show --output none
 
 targets:
   updateVersion:

--- a/updatecli/updatecli.d/windows-2019-images.yml
+++ b/updatecli/updatecli.d/windows-2019-images.yml
@@ -18,9 +18,12 @@ sources:
     kind: shell
     name: Get the latest `windows 2019` image version
     spec:
+      command: az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID > /dev/null && az vm image list --location eastus --publisher MicrosoftWindowsServer --offer WindowsServer --sku 2019-datacenter-core-g2 --all --query "[?offer=='WindowsServer'].version" -o tsv | sort -u | tail -n 1
       environments:
         - name: PATH
-      command: az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID > /dev/null && az vm image list --location eastus --publisher MicrosoftWindowsServer --offer WindowsServer --sku 2019-datacenter-core-g2 --all --query "[?offer=='WindowsServer'].version" -o tsv | sort -u | tail -n 1
+        - name: AZURE_CLIENT_ID
+        - name: AZURE_CLIENT_SECRET
+        - name: AZURE_TENANT_ID
 
 targets:
   updateVersion:

--- a/updatecli/updatecli.d/windows-2019-images.yml
+++ b/updatecli/updatecli.d/windows-2019-images.yml
@@ -32,8 +32,11 @@ targets:
     kind: yaml
     scmid: default
     spec:
-      file: "packer-versions.yaml"
-      key: "$.windows_image_version.2019"
+      file: ./images-versions.yaml
+      key: $.windows_image_version.2019
+    transformers:
+      - addprefix: '"'
+      - addsuffix: '"'
 
 actions:
   default:

--- a/updatecli/updatecli.d/windows-2019-images.yml
+++ b/updatecli/updatecli.d/windows-2019-images.yml
@@ -33,7 +33,7 @@ targets:
     scmid: default
     spec:
       file: ./images-versions.yaml
-      key: $.windows_image_version.2019
+      key: $.azure.windows.2019.amd64
     transformers:
       - addprefix: '"'
       - addsuffix: '"'

--- a/updatecli/updatecli.d/windows-2019-images.yml
+++ b/updatecli/updatecli.d/windows-2019-images.yml
@@ -20,7 +20,7 @@ sources:
     spec:
       environments:
         - name: PATH
-      command: az login --service-principal -u "$PACKER_AZURE_CLIENT_ID" -p "$PACKER_AZURE_CLIENT_SECRET" -t "$PACKER_AZURE_TENANT_ID" && az vm image list --location eastus --publisher MicrosoftWindowsServer --offer WindowsServer --sku 2019-datacenter-core-g2 --all --query "[?offer=='WindowsServer'].version" -o tsv | sort -u | tail -n 1
+      command: az vm image list --location eastus --publisher MicrosoftWindowsServer --offer WindowsServer --sku 2019-datacenter-core-g2 --all --query "[?offer=='WindowsServer'].version" -o tsv | sort -u | tail -n 1
 
 conditions:
   checkifazcommandwork:
@@ -29,7 +29,7 @@ conditions:
     spec:
       environments:
         - name: PATH
-      command: az login --service-principal -u "$PACKER_AZURE_CLIENT_ID" -p "$PACKER_AZURE_CLIENT_SECRET" -t "$PACKER_AZURE_TENANT_ID" && az account show --output none
+      command: az account show --output none
 
 targets:
   updateVersion:

--- a/updatecli/updatecli.d/windows-2019-images.yml
+++ b/updatecli/updatecli.d/windows-2019-images.yml
@@ -20,18 +20,17 @@ sources:
     spec:
       environments:
         - name: PATH
-      command: az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET -t $AZURE_TENANT_ID && az vm image list --location eastus --publisher MicrosoftWindowsServer --offer WindowsServer --sku 2019-datacenter-core-g2 --all --query "[?offer=='WindowsServer'].version" -o tsv | sort -u | tail -n 1
+      command: az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID > /dev/null && az vm image list --location eastus --publisher MicrosoftWindowsServer --offer WindowsServer --sku 2019-datacenter-core-g2 --all --query "[?offer=='WindowsServer'].version" -o tsv | sort -u | tail -n 1
 
 targets:
   updateVersion:
     name: Update azure `windows 2019` image version in locals
     sourceid: lastReleaseVersion
-    kind: file # not terraform/file as per updatecli/updatecli#1859 need to use matchpattern and replacepattern for now
+    kind: yaml
     scmid: default
     spec:
-      file: "locals.pkr.hcl"
-      matchpattern: (windows_image_version.*(\r\n|\r|\n).*\"2019\".*=.*\")(.*)(\".*)
-      replacepattern: ${1}{{ source "lastReleaseVersion" }}"
+      file: "packer-versions.yaml"
+      key: "$.windows_image_version.2019"
 
 actions:
   default:

--- a/updatecli/updatecli.d/windows-2019-images.yml
+++ b/updatecli/updatecli.d/windows-2019-images.yml
@@ -22,6 +22,15 @@ sources:
         - name: PATH
       command: az vm image list --location eastus --publisher MicrosoftWindowsServer --offer WindowsServer --sku 2019-datacenter-core-g2 --all --query "[?offer=='WindowsServer'].version" -o tsv | sort -u | tail -n 1
 
+conditions:
+  checkifazcommandwork:
+    kind: shell
+    disablesourceinput: true
+    spec:
+      environments:
+        - name: PATH
+      command: az account show --output none
+
 targets:
   updateVersion:
     name: Update azure `windows 2019` image version in locals

--- a/updatecli/updatecli.d/windows-2019-images.yml
+++ b/updatecli/updatecli.d/windows-2019-images.yml
@@ -1,0 +1,44 @@
+---
+name: Bump azure `windows 2019` image version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastReleaseVersion:
+    kind: shell
+    name: Get the latest `windows 2019` image version
+    spec:
+      environments:
+        - name: PATH
+      command: az vm image list --location eastus --publisher MicrosoftWindowsServer --offer WindowsServer --sku 2019-datacenter-core-g2 --all --query "[?offer=='WindowsServer'].version" -o tsv | sort -u | tail -n 1
+
+targets:
+  updateVersion:
+    name: Update azure `windows 2019` image version in locals
+    sourceid: lastReleaseVersion
+    kind: file # not terraform/file as per updatecli/updatecli#1859 need to use matchpattern and replacepattern for now
+    scmid: default
+    spec:
+      file: "locals.pkr.hcl"
+      matchpattern: (windows_image_version.*(\r\n|\r|\n).*\"2019\".*=.*\")(.*)(\".*)
+      replacepattern: ${1}{{ source "lastReleaseVersion" }}"
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      title: Bump azure `windows 2019` image version
+      description: "Follow up azure images for windows 2019"
+      labels:
+        - enhancement

--- a/updatecli/updatecli.d/windows-2019-images.yml
+++ b/updatecli/updatecli.d/windows-2019-images.yml
@@ -20,16 +20,7 @@ sources:
     spec:
       environments:
         - name: PATH
-      command: az vm image list --location eastus --publisher MicrosoftWindowsServer --offer WindowsServer --sku 2019-datacenter-core-g2 --all --query "[?offer=='WindowsServer'].version" -o tsv | sort -u | tail -n 1
-
-conditions:
-  checkifazcommandwork:
-    kind: shell
-    disablesourceinput: true
-    spec:
-      environments:
-        - name: PATH
-      command: az account show --output none
+      command: az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET -t $AZURE_TENANT_ID && az vm image list --location eastus --publisher MicrosoftWindowsServer --offer WindowsServer --sku 2019-datacenter-core-g2 --all --query "[?offer=='WindowsServer'].version" -o tsv | sort -u | tail -n 1
 
 targets:
   updateVersion:

--- a/updatecli/updatecli.d/windows-2022-images.yml
+++ b/updatecli/updatecli.d/windows-2022-images.yml
@@ -32,8 +32,11 @@ targets:
     kind: yaml
     scmid: default
     spec:
-      file: "packer-versions.yaml"
-      key: "$.windows_image_version.2022"
+      file: ./images-versions.yaml
+      key: $.windows_image_version.2022
+    transformers:
+      - addprefix: '"'
+      - addsuffix: '"'
 
 actions:
   default:

--- a/updatecli/updatecli.d/windows-2022-images.yml
+++ b/updatecli/updatecli.d/windows-2022-images.yml
@@ -1,0 +1,42 @@
+---
+name: Bump azure `windows 2022` image version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastReleaseVersion:
+    kind: shell
+    name: Get the latest `windows 2022` image version
+    spec:
+      command: az vm image list --location eastus --publisher MicrosoftWindowsServer --offer WindowsServer --sku 2022-datacenter-core-g2 --all --query "[?offer=='WindowsServer'].version" -o tsv | sort -u | tail -n 1
+
+targets:
+  updateVersion:
+    name: Update azure `windows 2022` image version in locals
+    sourceid: lastReleaseVersion
+    kind: file # not terraform/file as per updatecli/updatecli#1859 need to use matchpattern and replacepattern for now
+    scmid: default
+    spec:
+      file: "locals.pkr.hcl"
+      matchpattern: (windows_image_version.*(\r\n|\r|\n).*(\r\n|\r|\n).*\"2022\".*=.*\")(.*)(\".*)
+      replacepattern: ${1}{{ source "lastReleaseVersion" }}"
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      title: Bump azure `windows 2022` image version
+      description: "Follow up azure images for windows 2022"
+      labels:
+        - enhancement

--- a/updatecli/updatecli.d/windows-2022-images.yml
+++ b/updatecli/updatecli.d/windows-2022-images.yml
@@ -20,6 +20,15 @@ sources:
     spec:
       command: az vm image list --location eastus --publisher MicrosoftWindowsServer --offer WindowsServer --sku 2022-datacenter-core-g2 --all --query "[?offer=='WindowsServer'].version" -o tsv | sort -u | tail -n 1
 
+conditions:
+  checkifazcommandwork:
+    kind: shell
+    disablesourceinput: true
+    spec:
+      environments:
+        - name: PATH
+      command: az account show --output none
+
 targets:
   updateVersion:
     name: Update azure `windows 2022` image version in locals

--- a/updatecli/updatecli.d/windows-2022-images.yml
+++ b/updatecli/updatecli.d/windows-2022-images.yml
@@ -18,16 +18,7 @@ sources:
     kind: shell
     name: Get the latest `windows 2022` image version
     spec:
-      command: az vm image list --location eastus --publisher MicrosoftWindowsServer --offer WindowsServer --sku 2022-datacenter-core-g2 --all --query "[?offer=='WindowsServer'].version" -o tsv | sort -u | tail -n 1
-
-conditions:
-  checkifazcommandwork:
-    kind: shell
-    disablesourceinput: true
-    spec:
-      environments:
-        - name: PATH
-      command: az account show --output none
+      command: az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET -t $AZURE_TENANT_ID && az vm image list --location eastus --publisher MicrosoftWindowsServer --offer WindowsServer --sku 2022-datacenter-core-g2 --all --query "[?offer=='WindowsServer'].version" -o tsv | sort -u | tail -n 1
 
 targets:
   updateVersion:

--- a/updatecli/updatecli.d/windows-2022-images.yml
+++ b/updatecli/updatecli.d/windows-2022-images.yml
@@ -19,6 +19,11 @@ sources:
     name: Get the latest `windows 2022` image version
     spec:
       command: az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID > /dev/null && az vm image list --location eastus --publisher MicrosoftWindowsServer --offer WindowsServer --sku 2022-datacenter-core-g2 --all --query "[?offer=='WindowsServer'].version" -o tsv | sort -u | tail -n 1
+      environments:
+        - name: PATH
+        - name: AZURE_CLIENT_ID
+        - name: AZURE_CLIENT_SECRET
+        - name: AZURE_TENANT_ID
 
 targets:
   updateVersion:

--- a/updatecli/updatecli.d/windows-2022-images.yml
+++ b/updatecli/updatecli.d/windows-2022-images.yml
@@ -33,7 +33,7 @@ targets:
     scmid: default
     spec:
       file: ./images-versions.yaml
-      key: $.windows_image_version.2022
+      key: $.azure.windows.2022.amd64
     transformers:
       - addprefix: '"'
       - addsuffix: '"'

--- a/updatecli/updatecli.d/windows-2022-images.yml
+++ b/updatecli/updatecli.d/windows-2022-images.yml
@@ -18,7 +18,7 @@ sources:
     kind: shell
     name: Get the latest `windows 2022` image version
     spec:
-      command: az login --service-principal -u "$PACKER_AZURE_CLIENT_ID" -p "$PACKER_AZURE_CLIENT_SECRET" -t "$PACKER_AZURE_TENANT_ID" && az vm image list --location eastus --publisher MicrosoftWindowsServer --offer WindowsServer --sku 2022-datacenter-core-g2 --all --query "[?offer=='WindowsServer'].version" -o tsv | sort -u | tail -n 1
+      command: az vm image list --location eastus --publisher MicrosoftWindowsServer --offer WindowsServer --sku 2022-datacenter-core-g2 --all --query "[?offer=='WindowsServer'].version" -o tsv | sort -u | tail -n 1
 
 conditions:
   checkifazcommandwork:
@@ -27,7 +27,7 @@ conditions:
     spec:
       environments:
         - name: PATH
-      command: az login --service-principal -u "$PACKER_AZURE_CLIENT_ID" -p "$PACKER_AZURE_CLIENT_SECRET" -t "$PACKER_AZURE_TENANT_ID" && az account show --output none
+      command: az account show --output none
 
 targets:
   updateVersion:

--- a/updatecli/updatecli.d/windows-2022-images.yml
+++ b/updatecli/updatecli.d/windows-2022-images.yml
@@ -18,18 +18,17 @@ sources:
     kind: shell
     name: Get the latest `windows 2022` image version
     spec:
-      command: az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET -t $AZURE_TENANT_ID && az vm image list --location eastus --publisher MicrosoftWindowsServer --offer WindowsServer --sku 2022-datacenter-core-g2 --all --query "[?offer=='WindowsServer'].version" -o tsv | sort -u | tail -n 1
+      command: az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID > /dev/null && az vm image list --location eastus --publisher MicrosoftWindowsServer --offer WindowsServer --sku 2022-datacenter-core-g2 --all --query "[?offer=='WindowsServer'].version" -o tsv | sort -u | tail -n 1
 
 targets:
   updateVersion:
     name: Update azure `windows 2022` image version in locals
     sourceid: lastReleaseVersion
-    kind: file # not terraform/file as per updatecli/updatecli#1859 need to use matchpattern and replacepattern for now
+    kind: yaml
     scmid: default
     spec:
-      file: "locals.pkr.hcl"
-      matchpattern: (windows_image_version.*(\r\n|\r|\n).*(\r\n|\r|\n).*\"2022\".*=.*\")(.*)(\".*)
-      replacepattern: ${1}{{ source "lastReleaseVersion" }}"
+      file: "packer-versions.yaml"
+      key: "$.windows_image_version.2022"
 
 actions:
   default:

--- a/updatecli/updatecli.d/windows-2022-images.yml
+++ b/updatecli/updatecli.d/windows-2022-images.yml
@@ -18,7 +18,7 @@ sources:
     kind: shell
     name: Get the latest `windows 2022` image version
     spec:
-      command: az vm image list --location eastus --publisher MicrosoftWindowsServer --offer WindowsServer --sku 2022-datacenter-core-g2 --all --query "[?offer=='WindowsServer'].version" -o tsv | sort -u | tail -n 1
+      command: az login --service-principal -u "$PACKER_AZURE_CLIENT_ID" -p "$PACKER_AZURE_CLIENT_SECRET" -t "$PACKER_AZURE_TENANT_ID" && az vm image list --location eastus --publisher MicrosoftWindowsServer --offer WindowsServer --sku 2022-datacenter-core-g2 --all --query "[?offer=='WindowsServer'].version" -o tsv | sort -u | tail -n 1
 
 conditions:
   checkifazcommandwork:
@@ -27,7 +27,7 @@ conditions:
     spec:
       environments:
         - name: PATH
-      command: az account show --output none
+      command: az login --service-principal -u "$PACKER_AZURE_CLIENT_ID" -p "$PACKER_AZURE_CLIENT_SECRET" -t "$PACKER_AZURE_TENANT_ID" && az account show --output none
 
 targets:
   updateVersion:


### PR DESCRIPTION
follow up #1442 to keep track of azure windows images

`az vm image list --location eastus --publisher MicrosoftWindowsServer --offer WindowsServer --sku 2019-datacenter-core-g2 --all --query "[?offer=='WindowsServer'].version" -o tsv | sort -u | tail -n 1`

and

`az vm image list --location eastus --publisher MicrosoftWindowsServer --offer WindowsServer --sku 2022-datacenter-core-g2 --all --query "[?offer=='WindowsServer'].version" -o tsv | sort -u | tail -n 1`


------------------------------------------------------------------------------------------
Those commands need authentication ... sic ...

Converted to draft, until next week, where we will provide the authentication ...
done with https://github.com/jenkins-infra/azure/pull/860

and https://github.com/jenkins-infra/kubernetes-management/pull/5806