### PR TITLE
feat!(aws):Add Amazon-ebs builder for Windows 2019, 2022 AMIs

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -107,10 +107,36 @@ pipeline {
           axis {
             name 'compute_type'
             // "azure-arm" stands for "Azure Resource Manager", unrelated to arm64 CPU
-            values 'azure-arm', 'docker'
+            values 'amazon-ebs', 'azure-arm', 'docker'
           }
         }
         excludes {
+          // Only build Ubuntu images for arm64 CPU in AWS (notValues)
+          exclude {
+            axis {
+              name 'cpu_architecture'
+              values 'arm64'
+            }
+            axis {
+              name 'agent_type'
+              notValues 'ubuntu-22.04'
+            }
+            axis {
+              name 'compute_type'
+              values 'amazon-ebs'
+            }
+          }
+          // Exclude 'amazon-ebs' Ubuntu builds
+          exclude {
+            axis {
+              name 'agent_type'
+              values 'ubuntu-22.04'
+            }
+            axis {
+              name 'compute_type'
+              values 'amazon-ebs'
+            }
+          }
           // Only build Ubuntu images for arm64 CPU in Azure (notValues)
           exclude {
             axis {
@@ -149,6 +175,9 @@ pipeline {
           }
         }
         environment {
+          // Defines the following environment variables: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+          AWS_ACCESS_KEY_ID             = credentials('packer-aws-access-key-id')
+          AWS_SECRET_ACCESS_KEY         = credentials('packer-aws-secret-access-key')
           // Defines the following environment variables: AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID
           // Ref. https://plugins.jenkins.io/azure-credentials/#plugin-content-declarative-pipeline
           AZURE                         = credentials('packer-azure-serviceprincipal-sponsorship')

--- a/build-jenkins-agent-windows.pkr.hcl
+++ b/build-jenkins-agent-windows.pkr.hcl
@@ -1,4 +1,14 @@
 build {
+  source "amazon-ebs.base" {
+    name           = "windows"
+    communicator   = "winrm"
+    user_data_file = "./provisioning/setupWinRM.ps1"
+    winrm_insecure = true
+    winrm_timeout  = "20m"
+    winrm_use_ssl  = true
+    winrm_username = local.windows_winrm_user[var.image_type]
+  }
+
   source "azure-arm.base" {
     name         = "windows"
     communicator = "winrm"
@@ -132,3 +142,14 @@ build {
     ]
   }
 }
+# This provisioner must be the last for AWS EBS builds, after reboots
+  provisioner "powershell" {
+    only              = ["amazon-ebs.windows"]
+    elevated_user     = local.windows_winrm_user[var.image_type]
+    elevated_password = build.Password
+
+    inline = [
+      "& 'C:/Program Files/Amazon/EC2Launch/ec2launch' reset --block",
+      "& 'C:/Program Files/Amazon/EC2Launch/ec2launch' sysprep --block",
+    ]
+  }

--- a/datasources.pkr.hcl
+++ b/datasources.pkr.hcl
@@ -1,0 +1,42 @@
+//datasources for Linux AMI commented for later use
+
+# # # Data sources are always treated BEFORE locals and sources.
+# data "amazon-ami" "ubuntu-22_04" {
+#   access_key      = var.aws_access_key_id
+#   secret_key      = var.aws_secret_access_key
+#   filters = {
+#     name                = format("ubuntu/images/hvm-ssd/ubuntu-*-22.04-%s-server-*", var.architecture)
+#     root-device-type    = "ebs"
+#     virtualization-type = "hvm"
+#   }
+#   most_recent = true
+#   # owners      = ["326712726440"]
+#   owners      = ["amazon"]
+#   region      = var.aws_region
+# }
+data "amazon-ami" "windows-2019" {
+  access_key      = var.aws_access_key_id
+  secret_key      = var.aws_secret_access_key
+  filters = {
+    # https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ec2launch-v2.html
+    name                = "EC2LaunchV2-Windows_Server-2019-English-Core-Base-*"
+    root-device-type    = "ebs"
+    virtualization-type = "hvm"
+  }
+  most_recent = true
+  owners      = ["amazon"]
+  region      = var.aws_region
+}
+
+data "amazon-ami" "windows-2022" {
+  access_key      = var.aws_access_key_id
+  secret_key      = var.aws_secret_access_key
+  filters = {
+    name                = "Windows_Server-2022-English-Core-Base-*"
+    root-device-type    = "ebs"
+    virtualization-type = "hvm"
+  }
+  most_recent = true
+  owners      = ["amazon"]
+  region      = var.aws_region
+}

--- a/datasources.pkr.hcl
+++ b/datasources.pkr.hcl
@@ -1,19 +1,18 @@
-//datasources for Linux AMI commented for later use
+# # Data sources are always treated BEFORE locals and sources.
+data "amazon-ami" "ubuntu-22_04" {
+  access_key      = var.aws_access_key_id
+  secret_key      = var.aws_secret_access_key
+  filters = {
+    name                = format("ubuntu/images/hvm-ssd/ubuntu-*-22.04-%s-server-*", var.architecture)
+    root-device-type    = "ebs"
+    virtualization-type = "hvm"
+  }
+  most_recent = true
+  # owners      = ["326712726440"]
+  owners      = ["amazon"]
+  region      = var.aws_region
+}
 
-# # # Data sources are always treated BEFORE locals and sources.
-# data "amazon-ami" "ubuntu-22_04" {
-#   access_key      = var.aws_access_key_id
-#   secret_key      = var.aws_secret_access_key
-#   filters = {
-#     name                = format("ubuntu/images/hvm-ssd/ubuntu-*-22.04-%s-server-*", var.architecture)
-#     root-device-type    = "ebs"
-#     virtualization-type = "hvm"
-#   }
-#   most_recent = true
-#   # owners      = ["326712726440"]
-#   owners      = ["amazon"]
-#   region      = var.aws_region
-# }
 data "amazon-ami" "windows-2019" {
   access_key      = var.aws_access_key_id
   secret_key      = var.aws_secret_access_key

--- a/locals.pkr.hcl
+++ b/locals.pkr.hcl
@@ -4,6 +4,18 @@ locals {
   agent_os_version_safe = replace(var.agent_os_version, ".", "_")
   image_name            = format("jenkins-agent-%s-%s-%s", var.agent_os_type, var.agent_os_version, var.architecture)
   unique_image_name     = format("%s-%s", local.image_name, local.now_unix_timestamp)
+  
+  # aws_spot_instance_types = { // for spot instances
+  #   # 4 vCPU x86 / 16 GB / $0.1670 - https://aws.amazon.com/en/ec2/instance-types/t3/#Product_Details
+  #   "amd64" = ["t3.xlarge", "t3a.xlarge", "t2.xlarge", "m6a.xlarge"]
+  #   # 4 vCPU ARM64 (Gravitnb)/ 16 GB / $0.1344 - https://aws.amazon.com/en/ec2/instance-types/t4/#Product_Details
+  #   "arm64" = ["t4g.xlarge", "m7g.xlarge"]
+  # }
+  aws_instance_types = {
+    "amd64" = "t3.xlarge"
+    "arm64" = "t4g.xlarge"
+  }
+  
   # List available SKUs with the command `az vm image list-skus --offer 0001-com-ubuntu-server-jammy --location eastus --publisher canonical --output table`
   az_instance_image_sku = {
     "amd64" = "${local.agent_os_version_safe}-lts-gen2"

--- a/locals.pkr.hcl
+++ b/locals.pkr.hcl
@@ -15,7 +15,7 @@ locals {
     "amd64" = "t3.xlarge"
     "arm64" = "t4g.xlarge"
   }
-  
+
   # List available SKUs with the command `az vm image list-skus --offer 0001-com-ubuntu-server-jammy --location eastus --publisher canonical --output table`
   az_instance_image_sku = {
     "amd64" = "${local.agent_os_version_safe}-lts-gen2"
@@ -24,6 +24,7 @@ locals {
   windows_winrm_user = {
     "azure-arm" = "packer"
     "docker"    = "packer"
+    "amazon-ebs" = "Administrator" # In AWS EC2, WinRM super admin must be the "Administrator" account
   }
 
   # List available images `az vm image list --location eastus --publisher MicrosoftWindowsServer --offer WindowsServer --sku 2022-datacenter-core-g2 --all --output table`

--- a/main.pkr.hcl
+++ b/main.pkr.hcl
@@ -1,6 +1,10 @@
 packer {
   required_version = ">= 1.7.2, < 2"
   required_plugins {
+    amazon = {
+      version = "1.3.3"
+      source  = "github.com/hashicorp/amazon"
+    }
     windows-update = {
       version = "0.16.8"
       source  = "github.com/rgl/windows-update"

--- a/sources.pkr.hcl
+++ b/sources.pkr.hcl
@@ -1,3 +1,47 @@
+# This source defines all the common settings for any AWS AMI (whatever Operating System)
+source "amazon-ebs" "base" {
+  # profile       = "terraform-developer"
+
+  # AWS API connection
+  access_key      = var.aws_access_key_id
+  secret_key      = var.aws_secret_access_key
+
+  ami_name      = "${local.image_name}-${var.architecture}-${local.now_unix_timestamp}"
+  # spot_instance_types = local.aws_spot_instance_types[var.architecture] // if spot instances is used
+  # spot_price          = "auto"
+  instance_type = local.aws_instance_types[var.architecture]
+  # instance_type = "t2.xlarge"
+
+
+  # Define custom rootfs for build to avoid later filesystem extension during agent startups
+  launch_block_device_mappings {
+    delete_on_termination = true
+    device_name           = "/dev/sda1"
+    volume_size           = local.windows_disk_size_gb
+    volume_type           = "gp2"
+  }
+
+  # Where to build the VM
+  region = var.aws_region
+
+  # Where to export the AMI
+  ami_regions = [
+    var.aws_region
+  ]
+
+  # Egg-and-chicken: what is the base image to start from (eg. what is my egg)?
+  source_ami = data.amazon-ami["${var.agent_os_type}-${local.agent_os_version_safe}"].id
+  # To improve audit and garbage collecting, we provide tags
+  tags = {
+    imageplatform = var.architecture
+    imagetype     = local.image_name
+    timestamp     = local.now_unix_timestamp
+    version       = var.image_version
+    scm_ref       = var.scm_ref
+    build_type    = var.build_type
+  }
+}
+
 # This source defines all the common settings for any Azure image (whatever Operating System)
 source "azure-arm" "base" {
   managed_image_resource_group_name = local.azure_destination_resource_group

--- a/updatecli/updatecli.d/packer-plugins/amazon.yaml
+++ b/updatecli/updatecli.d/packer-plugins/amazon.yaml
@@ -1,0 +1,50 @@
+---
+name: Bump packer amazon plugin version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastReleaseVersion:
+    kind: githubrelease
+    name: Get the latest packer's amazon plugin version
+    spec:
+      owner: "hashicorp"
+      repository: "packer-plugin-amazon"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: semver
+    transformers:
+      - trimprefix: v
+
+targets:
+  updateVersion:
+    name: "Update the amazon plugin version in main.pkr.hcl"
+    sourceid: lastReleaseVersion
+    kind: file
+    spec:
+      file: main.pkr.hcl
+      matchpattern: 'amazon = \{((\r\n|\r|\n)(\s+))version = ".*"'
+      replacepattern: >-
+        amazon = {${1}version = "{{ source "lastReleaseVersion" }}"
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    title: Bump packer amazon plugin version to {{ source "lastReleaseVersion" }}
+    scmid: default
+    spec:
+      labels:
+        - dependencies
+        - packer-amazon-plugin

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -13,6 +13,18 @@ variable "architecture" {
   description = "CPU architecture ID of the build with the following possible values: [amd64 (default), arm64]"
   default     = "amd64"
 }
+variable "aws_region" {
+  type    = string
+  default = "us-east-2"
+}
+variable "aws_access_key_id" {
+  type    = string
+  default = env("AWS_ACCESS_KEY_ID")
+}
+variable "aws_secret_access_key" {
+  type    = string
+  default = env("AWS_SECRET_ACCESS_KEY")
+}
 variable "azure_client_id" {
   type    = string
   default = env("AZURE_CLIENT_ID")
@@ -35,7 +47,7 @@ variable "image_version" {
 }
 variable "image_type" {
   type        = string
-  description = "Which kind of Packer builder to use (e.g. cloud platform): [azure-arm (default), docker]"
+  description = "Which kind of Packer builder to use (e.g. cloud platform): [amazon-ebs, azure-arm (default), docker]"
   default     = "azure-arm"
 }
 variable "build_type" {


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/4353#issue-2586531372

Related to https://github.com/jenkins-infra/helpdesk/issues/4316#issuecomment-2410363812

This PR introduces the following to packer-images:

- Add amazon-ebs builder logic for windows builds in Jenkinsfile_k8s
- Include EC2 source for build-jenkins-agent-windows.pkr.hcl
 - Add datasources.pkr.hcl to look-up windows-2019 and windows-2022 AMI ids for respective architecture
-  Define windows_winrm_user in locals.pkr.hcl as administrator for amazon-ebs since admin permissions are required to ssh our windows ec2 agents
- Powershell provisioner added at the end for AWS EBS Windows builds, after reboots
-  Define all the common settings for AWS base image AMI's in sources.pkr.hcl