### PR TITLE
chore(ubuntu): Use pinned aws base AMI IDs from `images-versions.yaml`

### DIFF
--- a/build-jenkins-agent-ubuntu.pkr.hcl
+++ b/build-jenkins-agent-ubuntu.pkr.hcl
@@ -8,6 +8,7 @@ build {
     ssh_username = "ubuntu"
     # Egg-and-chicken: what is the base image to start from (eg. what is my egg)?
     source_ami = local.aws_ubuntu_amis[var.architecture]
+    source_ami = try(local.images_versions["aws"]["ubuntu"][var.agent_os_version][var.architecture], "N/A")
   }
 
   source "azure-arm.base" {

--- a/build-jenkins-agent-ubuntu.pkr.hcl
+++ b/build-jenkins-agent-ubuntu.pkr.hcl
@@ -7,7 +7,6 @@ build {
     name         = "ubuntu"
     ssh_username = "ubuntu"
     # Egg-and-chicken: what is the base image to start from (eg. what is my egg)?
-    source_ami = local.aws_ubuntu_amis[var.architecture]
     source_ami = try(local.images_versions["aws"]["ubuntu"][var.agent_os_version][var.architecture], "N/A")
   }
 

--- a/locals.pkr.hcl
+++ b/locals.pkr.hcl
@@ -11,11 +11,6 @@ locals {
     "arm64" = "t4g.xlarge"
   }
   # TODO: track AMI versions with `updatecli`
-  # Uses aws ec2 describe-images to fetch the ami id as per the architecture
-  aws_ubuntu_amis = {
-    "amd64" = "ami-00eb69d236edcfaf8"
-    "arm64" = "ami-039e419d24a37cb82"
-  }
   # List available SKUs with the command `az vm image list-skus --offer 0001-com-ubuntu-server-jammy --location eastus --publisher canonical --output table`
   az_instance_image_sku = {
     "amd64" = "${local.agent_os_version_safe}-lts-gen2"


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/4365#issue-2610776824

and https://github.com/jenkins-infra/packer-images/pull/1443

We want to use the aws `ubuntu` pinned AMI Ids in `image-versions.yaml`, hence the `source_ami` is retrieved from there.