### PR TITLE
chore(updatecli):Track `ubuntu 22.04 AMD64` AMI ID

### DIFF
--- a/updatecli/updatecli.d/ubuntu-22-04-amd64-images.yaml
+++ b/updatecli/updatecli.d/ubuntu-22-04-amd64-images.yaml
@@ -1,5 +1,5 @@
 ---
-name: Bump aws `ubuntu 22.04 AMD64` image version
+name: Bump aws `ubuntu 22.04 AMD64` AMI ID
 
 scms:
   default:

--- a/updatecli/updatecli.d/ubuntu-22-04-images.yaml
+++ b/updatecli/updatecli.d/ubuntu-22-04-images.yaml
@@ -1,0 +1,55 @@
+---
+name: Bump aws `ubuntu 22.04 AMD64` image version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastReleaseVersion:
+    kind: shell
+    name: Get the latest `ubuntu 22.04 AMD64` AMI ID
+    spec:
+      command: >
+        aws ec2 describe-images \
+          --owners 099720109477 \
+          --filters \
+            "Name=name,Values=ubuntu/images/hvm-ssd/ubuntu-*-22.04-*-server-*" \
+            "Name=root-device-type,Values=ebs" \
+            "Name=virtualization-type,Values=hvm" \
+            "Name=architecture,Values=x86_64" \
+          --query 'sort_by(Images, &CreationDate)[-1].ImageId' \
+          --region us-east-2 \
+          --output text
+      environments:
+        - name: PATH
+        - name: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+
+targets:
+  updateVersion:
+    name: Update aws `ubuntu 22.04 AMD64` AMI ID in locals
+    sourceid: lastReleaseVersion
+    kind: yaml
+    scmid: default
+    spec:
+      file: ./images-versions.yaml
+      key: $.aws.ubuntu.'22.04'.amd64
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      title: Bump aws `ubuntu 22.04 AMD64` AMI ID
+      description: "Update AWS AMI ID for Ubuntu 22.04 AMD64"
+      labels:
+        - enhancement


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/4365#issue-2610776824:

As we pinned the base AMI ids for `ubuntu 22.04`, this PR tracks and updates the latest base AMI id of `ubuntu 22.04 AMD64`

Tested locally and successfully:

```
TARGETS
========

updateVersion
-------------

**Dry Run enabled**

✔ - no change detected:
        * key "$.aws.ubuntu.'22.04'.amd64" already set to "ami-00eb69d236edcfaf8", from file "./images-versions.yaml"


ACTIONS
========


=============================

SUMMARY:



✔ Bump aws `ubuntu 22.04 AMD64` image version:
        Source:
                ✔ [lastReleaseVersion] Get the latest `ubuntu 22.04 AMD64` AMI ID
        Target:
                ✔ [updateVersion] Update aws `ubuntu 22.04 AMD64` AMI ID in locals


Run Summary
===========
Pipeline(s) run:
  * Changed:    0
  * Failed:     0
  * Skipped:    0
  * Succeeded:  1
  * Total:      1