### PR TITLE
chore(updatecli):Track `ubuntu 22_04 AMD64` AZ images

### DIFF
--- a/build-jenkins-agent-ubuntu.pkr.hcl
+++ b/build-jenkins-agent-ubuntu.pkr.hcl
@@ -17,6 +17,7 @@ build {
     image_publisher = "canonical"
     # List available SKUs with the command `az vm image list-skus --offer 0001-com-ubuntu-server-jammy --location eastus --publisher canonical --output table`
     image_sku = local.az_instance_image_sku[var.architecture]
+    image_version = try(local.images_versions["azure"]["ubuntu"][var.agent_os_version][var.architecture], "N/A")
     os_type   = "Linux"
   }
 

--- a/updatecli/updatecli.d/az-ubuntu-22-04-amd64-images.yml
+++ b/updatecli/updatecli.d/az-ubuntu-22-04-amd64-images.yml
@@ -18,7 +18,7 @@ sources:
     kind: shell
     name: Get the latest `ubuntu 22.04` amd64 image version from Azure
     spec:
-      command: az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID > /dev/null && az vm image list --location eastus --publisher Canonical --offer UbuntuServer --sku 22.04-LTS --all --query "[?sku=='22.04-LTS'].version" -o tsv | sort -u | tail -n 1
+      command: az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID > /dev/null && az vm image list --location eastus --publisher Canonical --offer UbuntuServer --sku 22.04-LTS-AMD64 --all --query "[?sku=='22.04-LTS-AMD64'].version" -o tsv | sort -u | tail -n 1
       environments:
         - name: PATH
         - name: AZURE_CLIENT_ID

--- a/updatecli/updatecli.d/az-ubuntu-22-04-amd64-images.yml
+++ b/updatecli/updatecli.d/az-ubuntu-22-04-amd64-images.yml
@@ -43,7 +43,7 @@ actions:
     kind: github/pullrequest
     scmid: default
     spec:
-      title: Bump azure `ubuntu 22.04` amd64 image version
+      title: Bump Azure Ubuntu `22.04` amd64 image version
       description: "Update the latest Azure Ubuntu 22.04 amd64 image version in the images-versions.yaml file."
       labels:
         - enhancement

--- a/updatecli/updatecli.d/az-ubuntu-22-04-amd64-images.yml
+++ b/updatecli/updatecli.d/az-ubuntu-22-04-amd64-images.yml
@@ -33,7 +33,7 @@ targets:
     scmid: default
     spec:
       file: ./images-versions.yaml
-      key: $.azure.ubuntu."22.04".amd64
+      key: $.azure.ubuntu.'22.04'.amd64
     transformers:
       - addprefix: '"'
       - addsuffix: '"'

--- a/updatecli/updatecli.d/az-ubuntu-22-04-amd64-images.yml
+++ b/updatecli/updatecli.d/az-ubuntu-22-04-amd64-images.yml
@@ -18,7 +18,7 @@ sources:
     kind: shell
     name: Get the latest `ubuntu 22.04` amd64 image version from Azure
     spec:
-      command: az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID > /dev/null && az vm image list --location eastus --publisher Canonical --offer 0001-com-ubuntu-server-jammy --sku 22_04-AMD64-lts-gen2 --all --query "[?offer=='0001-com-ubuntu-server-jammy'].version" -o tsv | sort -u | tail -n 1
+      command: az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID > /dev/null && az vm image list --location eastus --publisher Canonical --offer 0001-com-ubuntu-server-jammy --sku 22_04-lts-gen2 --all --query "[?offer=='0001-com-ubuntu-server-jammy'].version" -o tsv | sort -u | tail -n 1
       environments:
         - name: PATH
         - name: AZURE_CLIENT_ID

--- a/updatecli/updatecli.d/az-ubuntu-22-04-amd64-images.yml
+++ b/updatecli/updatecli.d/az-ubuntu-22-04-amd64-images.yml
@@ -47,3 +47,4 @@ actions:
       description: "Update the latest Azure Ubuntu 22.04 amd64 image version in the images-versions.yaml file."
       labels:
         - enhancement
+        - ubuntu

--- a/updatecli/updatecli.d/az-ubuntu-22-04-amd64-images.yml
+++ b/updatecli/updatecli.d/az-ubuntu-22-04-amd64-images.yml
@@ -18,7 +18,7 @@ sources:
     kind: shell
     name: Get the latest `ubuntu 22.04` amd64 image version from Azure
     spec:
-      command: az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID > /dev/null && az vm image list --location eastus --publisher Canonical --offer UbuntuServer --sku 22.04-LTS-AMD64 --all --query "[?sku=='22.04-LTS-AMD64'].version" -o tsv | sort -u | tail -n 1
+      command: az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID > /dev/null && az vm image list --location eastus --publisher Canonical --offer 0001-com-ubuntu-server-jammy --sku 22.04-AMD64 --all --query "[?sku=='22.04-AMD64'].version" -o tsv | sort -u | tail -n 1
       environments:
         - name: PATH
         - name: AZURE_CLIENT_ID

--- a/updatecli/updatecli.d/az-ubuntu-22-04-amd64-images.yml
+++ b/updatecli/updatecli.d/az-ubuntu-22-04-amd64-images.yml
@@ -1,0 +1,49 @@
+---
+name: Bump azure `ubuntu 22.04` amd64 image version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastReleaseVersion:
+    kind: shell
+    name: Get the latest `ubuntu 22.04` amd64 image version from Azure
+    spec:
+      command: az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID > /dev/null && az vm image list --location eastus --publisher Canonical --offer UbuntuServer --sku 22.04-LTS --all --query "[?sku=='22.04-LTS'].version" -o tsv | sort -u | tail -n 1
+      environments:
+        - name: PATH
+        - name: AZURE_CLIENT_ID
+        - name: AZURE_CLIENT_SECRET
+        - name: AZURE_TENANT_ID
+
+targets:
+  updateVersion:
+    name: Update azure `ubuntu 22.04` amd64 image version in locals
+    sourceid: lastReleaseVersion
+    kind: yaml
+    scmid: default
+    spec:
+      file: ./images-versions.yaml
+      key: $.azure.ubuntu."22.04".amd64
+    transformers:
+      - addprefix: '"'
+      - addsuffix: '"'
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      title: Bump azure `ubuntu 22.04` amd64 image version
+      description: "Update the latest Azure Ubuntu 22.04 amd64 image version in the images-versions.yaml file."
+      labels:
+        - enhancement

--- a/updatecli/updatecli.d/az-ubuntu-22-04-amd64-images.yml
+++ b/updatecli/updatecli.d/az-ubuntu-22-04-amd64-images.yml
@@ -18,7 +18,7 @@ sources:
     kind: shell
     name: Get the latest `ubuntu 22.04` amd64 image version from Azure
     spec:
-      command: az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID > /dev/null && az vm image list --location eastus --publisher Canonical --offer 0001-com-ubuntu-server-jammy --sku 22.04-AMD64 --all --query "[?sku=='22.04-AMD64'].version" -o tsv | sort -u | tail -n 1
+      command: az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID > /dev/null && az vm image list --location eastus --publisher Canonical --offer 0001-com-ubuntu-server-jammy --sku 22_04-AMD64-lts-gen2 --all --query "[?offer=='0001-com-ubuntu-server-jammy'].version" -o tsv | sort -u | tail -n 1
       environments:
         - name: PATH
         - name: AZURE_CLIENT_ID


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/4365#issue-2610776824

This PR pins and tracks the latest AZ image for `ubuntu 22_04 AMD64`