### PR TITLE
chore(updatecli):Track docker image digests for `ubuntu 22_04 AMD64` and `ubuntu 22_04 ARM64`

### DIFF
--- a/images-versions.yaml
+++ b/images-versions.yaml
@@ -1,4 +1,3 @@
-# images-versions.yaml
 ---
 azure:
   windows:
@@ -15,3 +14,8 @@ aws:
     "22.04":
       amd64: ami-00eb69d236edcfaf8
       arm64: ami-039e419d24a37cb82
+docker:
+  ubuntu:
+    "22.04":
+      amd64: sha256:3d1556a8a18cf5307b121e0a98e93f1ddf1f3f8e092f1fddfd941254785b95d7
+      arm64: sha256:7c75ab2b0567edbb9d4834a2c51e462ebd709740d1f2c40bcd23c56e974fe2a8

--- a/images-versions.yaml
+++ b/images-versions.yaml
@@ -1,3 +1,4 @@
+# images-versions.yaml
 ---
 azure:
   windows:

--- a/sources.pkr.hcl
+++ b/sources.pkr.hcl
@@ -74,7 +74,7 @@ source "azure-arm" "base" {
 
 # This source defines all the common settings for any Azure image (whatever Operating System)
 source "docker" "base" {
-  image = try(local.images_versions["docker"]["ubuntu"][var.agent_os_version][var.architecture], "N/A")
+  image = try("${var.agent_os_type}@${local.images_versions["docker"]["ubuntu"][var.agent_os_version][var.architecture]}", "N/A")
 
   # Persist image on local docker engine
   commit = true

--- a/sources.pkr.hcl
+++ b/sources.pkr.hcl
@@ -74,7 +74,7 @@ source "azure-arm" "base" {
 
 # This source defines all the common settings for any Azure image (whatever Operating System)
 source "docker" "base" {
-  image = "${var.agent_os_type}:${var.agent_os_version}"
+  image = try(local.images_versions["docker"]["ubuntu"][var.agent_os_version][var.architecture], "N/A")
 
   # Persist image on local docker engine
   commit = true

--- a/updatecli/updatecli.d/docker-ubuntu-22-04-amd64-images.yml
+++ b/updatecli/updatecli.d/docker-ubuntu-22-04-amd64-images.yml
@@ -1,0 +1,43 @@
+---
+name: Bump docker `ubuntu 22_04 amd64` image version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastDockerDigest:
+    kind: dockerdigest
+    spec:
+      image: "ubuntu"
+      tag: "22.04"
+      architecture: "amd64"
+
+targets:
+  updateDigest:
+    name: Update docker `ubuntu 22_04 amd64` image version in locals
+    sourceid: lastDockerDigest
+    kind: yaml
+    spec:
+      file: ./images-versions.yaml
+      key: $.docker.ubuntu.'22.04'.amd64
+    transformers:
+      - trimprefix: '22.04@'
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      title: Bump docker `ubuntu 22_04 amd64` image version
+      description: "Follow up docker images for ubuntu 22_04 amd64"
+      labels:
+        - enhancement

--- a/updatecli/updatecli.d/docker-ubuntu-22-04-amd64-images.yml
+++ b/updatecli/updatecli.d/docker-ubuntu-22-04-amd64-images.yml
@@ -26,6 +26,7 @@ targets:
     name: Update docker `ubuntu 22_04 amd64` image version in locals
     sourceid: lastDockerDigest
     kind: yaml
+    scmid: default
     spec:
       file: ./images-versions.yaml
       key: $.docker.ubuntu.'22.04'.amd64

--- a/updatecli/updatecli.d/docker-ubuntu-22-04-arm64-images.yml
+++ b/updatecli/updatecli.d/docker-ubuntu-22-04-arm64-images.yml
@@ -26,6 +26,7 @@ targets:
     name: Update docker `ubuntu 22_04 arm64` image version in locals
     sourceid: lastDockerDigest
     kind: yaml
+    scmid: default
     spec:
       file: ./images-versions.yaml
       key: $.docker.ubuntu.'22.04'.arm64

--- a/updatecli/updatecli.d/docker-ubuntu-22-04-arm64-images.yml
+++ b/updatecli/updatecli.d/docker-ubuntu-22-04-arm64-images.yml
@@ -1,0 +1,43 @@
+---
+name: Bump docker `ubuntu 22_04 arm64` image version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastDockerDigest:
+    kind: dockerdigest
+    spec:
+      image: "ubuntu"
+      tag: "22.04"
+      architecture: "arm64"
+
+targets:
+  updateDigest:
+    name: Update docker `ubuntu 22_04 arm64` image version in locals
+    sourceid: lastDockerDigest
+    kind: yaml
+    spec:
+      file: ./images-versions.yaml
+      key: $.docker.ubuntu.'22.04'.arm64
+    transformers:
+      - trimprefix: '22.04@'
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      title: Bump docker `ubuntu 22_04 arm64` image version
+      description: "Follow up docker images for ubuntu 22_04 arm64"
+      labels:
+        - enhancement


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/4365#issue-2610776824

This PR pins and track docker image digests for `ubuntu 22_04 AMD64` and `ubuntu 22_04 ARM64`