### PR TITLE
Revert "Bump `ruby` version to 3.3.6"

### DIFF
--- a/provisioning/tools-versions.yml
+++ b/provisioning/tools-versions.yml
@@ -39,7 +39,7 @@ openssh_authorized_keys_url: https://raw.githubusercontent.com/jenkins-infra/aws
 packer_version: 1.11.2
 python3_version: 3.12.6
 ruby_puppet_version: 2.6.10
-ruby_version: 3.3.6
+ruby_version: 3.3.5
 sops_version: 3.9.1
 terraform_version: 1.9.8
 trivy_version: 0.57.0

--- a/tests/goss-linux.yaml
+++ b/tests/goss-linux.yaml
@@ -102,7 +102,7 @@ command:
     exit-status: 0
     stdout:
       - 2.6.10
-      - 3.3.6
+      - 3.3.5
   rngd:
     exec: rngd --version
     exit-status: 0

--- a/tests/goss-windows.yaml
+++ b/tests/goss-windows.yaml
@@ -55,7 +55,7 @@ command:
     exec: ruby -v
     exit-status: 0
     stdout:
-      - 3.3.6
+      - 3.3.5
   vagrant:
     exec: vagrant --version
     exit-status: 0


### PR DESCRIPTION
Reverts jenkins-infra/packer-images#1501

Builds are failing due to this version not available in the ASDF ruby plugin (until https://github.com/asdf-vm/asdf-ruby/pull/419 is merged).