### PR TITLE
chore(updatecli) when a new Ruby version is available, check for its existence in the ASDF Ruby plugin

### DIFF
--- a/updatecli/updatecli.d/ruby.yml
+++ b/updatecli/updatecli.d/ruby.yml
@@ -28,9 +28,23 @@ sources:
           \d\.\d\.\d$
 
 conditions:
+  checkForAsdf:
+    kind: shell
+    disablesourceinput: true
+    dependson:
+      - "source#rubyDockerImageLatestVersion"
+    spec:
+      environments:
+        - name: PATH
+        - name: HOME
+      # Assuming ASDF is installed with the ruby package
+      command: bash -x -c "asdf list-all ruby | grep '^{{ source "rubyDockerImageLatestVersion" }}$' || { echo 'Ruby version {{ source "rubyDockerImageLatestVersion" }} not available yet on ASDF.' && exit 1; }"
+
   checkForChocolateyPackage:
     kind: shell
     disablesourceinput: true # Do not pass source as argument to the command line
+    dependson:
+      - "source#rubyDockerImageLatestVersion"
     spec:
       # The final ".1" is added to ruby version by Chocolatey
       command: curl --silent --show-error --location --fail --output /dev/null https://community.chocolatey.org/packages/ruby/{{ source "rubyDockerImageLatestVersion" }}.1

--- a/updatecli/updatecli.d/ruby.yml
+++ b/updatecli/updatecli.d/ruby.yml
@@ -38,7 +38,7 @@ conditions:
         - name: PATH
         - name: HOME
       # Assuming ASDF is installed with the ruby package
-      command: bash -x -c "asdf list-all ruby | grep '^{{ source "rubyDockerImageLatestVersion" }}$' || { echo 'Ruby version {{ source "rubyDockerImageLatestVersion" }} not available yet on ASDF.' && exit 1; }"
+      command: bash -x -c "asdf plugin-update ruby && asdf list-all ruby | grep '^{{ source "rubyDockerImageLatestVersion" }}$' || { echo 'Ruby version {{ source "rubyDockerImageLatestVersion" }} not available yet on ASDF.' && exit 1; }"
 
   checkForChocolateyPackage:
     kind: shell


### PR DESCRIPTION
This PR updates the `updatecli` manifest tracking Ruby version to add a condition checking if the latest found version exists in ASDF.

As seen in #1512 , we had to revert because the "latest" available version of Ruby was not (yet) available in ASDF.

Tested with:

- `3.3.5` as source version: works
- `3.3.6` as source version BEFORE https://github.com/asdf-vm/asdf-ruby/pull/419 was merged (or with an out of date ASDF index): conditions fails, no PR created but `updatecli` process continue working as expected
- `3.3.6` as source AFTER https://github.com/asdf-vm/asdf-ruby/pull/419  was merged: `updatecli` wants to create a new PR
- `3.3.7` (not existing when writing this PR): condition fail as expected