### PR TITLE
chore(`Jenkinsfile_k8s`) removes GC stage from pipeline

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -74,22 +74,6 @@ pipeline {
             }
           }
         }
-        stage('GC on Azure') {
-          environment {
-            PACKER_AZURE = credentials('packer-azure-serviceprincipal-sponsorship')
-          }
-          steps {
-            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-              sh 'az login --service-principal -u "$PACKER_AZURE_CLIENT_ID" -p "$PACKER_AZURE_CLIENT_SECRET" -t "$PACKER_AZURE_TENANT_ID"'
-              sh 'az account set -s "$PACKER_AZURE_SUBSCRIPTION_ID"'
-              sh './cleanup/azure_gallery_images.sh 1 dev'
-              sh './cleanup/azure_gallery_images.sh 7 staging'
-              sh './cleanup/azure.sh 1 dev'
-              sh './cleanup/azure.sh 1 staging'
-              sh './cleanup/azure.sh 1 prod'
-            }
-          }
-        }
       }
     }
     stage('Packer Images') {


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4355#issue-2586619289

As per https://github.com/jenkins-infra/packer-images/pull/1526#pullrequestreview-2438017043

This PR removes GC stage from `Jenkinsfile_k8` pipeline to make the garbage collector as a distinct job.