### PR TITLE
feat(jenkinsfile_gc) disables dryrun when run on main branch

### DIFF
--- a/Jenkinsfile_gc
+++ b/Jenkinsfile_gc
@@ -7,6 +7,9 @@ pipeline {
     }
     stages {
         stage('Garbage Collection') {
+            environment {
+                DRYRUN                = "${env.BRANCH_NAME == 'main' ? 'false' : 'true'}"
+            }
             parallel {
                 stage('GC on Azure') {
                     environment {
@@ -24,7 +27,6 @@ pipeline {
                 }
                 stage('GC on AWS us-east-2') {
                     environment {
-                        DRYRUN                = "${env.BRANCH_NAME == 'main' ? 'false' : 'true'}"
                         AWS_ACCESS_KEY_ID     = credentials('packer-aws-access-key-id')
                         AWS_SECRET_ACCESS_KEY = credentials('packer-aws-secret-access-key')
                         AWS_DEFAULT_REGION    = 'us-east-2'


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4355#issue-2586619289

As per https://github.com/jenkins-infra/packer-images/pull/1526#pullrequestreview-2438017043

We only run the build when branch is `main` and disable the `DRYRUN` for aws garbage collector.