### PR TITLE
chore(`Jenkinsfile_gc`) updates the agent used to `jnlp-linux-arm64`

### DIFF
--- a/Jenkinsfile_gc
+++ b/Jenkinsfile_gc
@@ -1,6 +1,6 @@
 pipeline {
     agent {
-        label "linux-arm64-docker"
+        label 'jnlp-linux-arm64'
     }
     triggers {
         cron('@hourly')


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4355#issue-2586619289

Since we don't use a docker agent, the agent label has been updated to a suitable agent for the `Jenkinsfile_gc` pipeline.