### PR TITLE
Revert "Bump jx-release-version version to 2.7.7"

### DIFF
--- a/provisioning/tools-versions.yml
+++ b/provisioning/tools-versions.yml
@@ -28,7 +28,7 @@ jdk21_version: 21.0.5+11
 jdk8_version: 8u432-b06
 jenkins_remoting_version: 3283.v92c105e0f819
 jq_version: 1.6
-jxreleaseversion_version: 2.7.7
+jxreleaseversion_version: 2.7.6
 kubectl_version: 1.29.10
 launchable_version: 1.66.0
 maven_version: 3.9.9

--- a/tests/goss-common.yaml
+++ b/tests/goss-common.yaml
@@ -65,7 +65,7 @@ command:
     exec: jx-release-version -version
     exit-status: 0
     stdout:
-      - 2.7.7
+      - 2.7.6
   kubectl:
     exec: kubectl version --client
     exit-status: 0


### PR DESCRIPTION
Reverts jenkins-infra/packer-images#1529 because https://github.com/jenkins-x-plugins/jx-release-version/issues/123