### PR TITLE
chore(`packer-images`) adds `Name` tag with a value matching the GC filter

### DIFF
--- a/sources.pkr.hcl
+++ b/sources.pkr.hcl
@@ -23,6 +23,7 @@ source "amazon-ebs" "base" {
 
   # To improve audit and garbage collecting, we provide tags
   tags = {
+    Name          = "${local.image_name}-Packer-${var.architecture}"
     imageplatform = var.architecture
     imagetype     = local.image_name
     timestamp     = local.now_unix_timestamp


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4355

As per https://github.com/jenkins-infra/helpdesk/issues/4355#issuecomment-2493454384

We add a `Name` tag with a value matching the GC filter to ensure all the dangling instances created by `packer-images` are terminated