### PR TITLE
chore(updatecli): update the updatecli manifest for the correct goss key stdout and not stderr anymore

### DIFF
--- a/updatecli/updatecli.d/updatecli.yml
+++ b/updatecli/updatecli.d/updatecli.yml
@@ -42,7 +42,7 @@ targets:
     spec:
       files:
         - tests/goss-common.yaml
-      key: $.command.updatecli.stderr[0]
+      key: $.command.updatecli.stdout[0]
     scmid: default
 
 actions:


### PR DESCRIPTION
as updatecli output it's version to stout now, we need to update our manifest.
Ref https://github.com/updatecli/updatecli/pull/2997