### PR TITLE
chore(GC/azure): fix Azure VM deletion by changing timeCreated to createdTime

### DIFF
--- a/cleanup/azure.sh
+++ b/cleanup/azure.sh
@@ -50,7 +50,7 @@ az account show >/dev/null || \
 resource_group_name="${build_type}-packer-builds"
 
 ## Remove resources in the "Resource Group" older than the threshold
-found_resource_ids="$(az resource list --resource-group="${resource_group_name}" | jq -r ".[] | select(.timeCreated < (\"${creation_date_threshold}\")) | .id")"
+found_resource_ids="$(az resource list --resource-group="${resource_group_name}" | jq -r ".[] | select(.createdTime < (\"${creation_date_threshold}\")) | .id")"
 
 if [ -n "${found_resource_ids}" ]
 then


### PR DESCRIPTION
ref: https://github.com/jenkins-infra/helpdesk/issues/4445

a `az resource show` show that the field existing is `createdTime` but not timeCreated, but I cannot find trace of that change on azure

```
{
  "changedTime": "2024-12-11T14:24:00.478990+00:00",
  "createdTime": "2024-12-11T14:24:00.452248+00:00",
  "extendedLocation": null,
  "id": "/subscriptions/<redacted>/resourceGroups/DEV-PACKER-BUILDS/providers/Microsoft.Compute/disks/pkrosmq3gtdonba",
  "identity": null,
  "kind": null,
  "location": "eastus2",
  "managedBy": "/subscriptions/<redacted>/resourceGroups/dev-packer-builds/providers/Microsoft.Compute/virtualMachines/pkrvmmq3gtdonba",
  "name": "pkrosmq3gtdonba",
  "plan": null,
  "properties": null,
  "provisioningState": "Succeeded",
  "resourceGroup": "DEV-PACKER-BUILDS",
  "sku": {
    "capacity": null,
    "family": null,
    "model": null,
    "name": "Standard_LRS",
    "size": null,
    "tier": "Standard"
  },
  "tags": {
    "build_type": "dev",
    "imageplatform": "amd64",
    "scm_ref": "9895aea21814bbccac18563c5a519232be8a5fe8",
    "timestamp": "20241211142322",
    "version": "0.1596.1"
  },
  "type": "Microsoft.Compute/disks"
}
```


if I select with timeCreated: `az resource list --resource-group=dev-packer-builds | jq -r '.[] | select(.timeCreated < ("2024-12-10")) | .id'`
it return data even if 20241210 is yesterday : 
```
az resource list --resource-group=dev-packer-builds | jq -r '.[] | select(.timeCreated < ("2024-12-10")) | .id'
/subscriptions/1311c09f-aee0-4d6c-99a4-392c2b543204/resourceGroups/DEV-PACKER-BUILDS/providers/Microsoft.Compute/disks/pkrosvrf05jjl6v
/subscriptions/1311c09f-aee0-4d6c-99a4-392c2b543204/resourceGroups/DEV-PACKER-BUILDS/providers/Microsoft.Compute/disks/pkros0a6rph6dsq
```

if I select with createdTime: `az resource list --resource-group=dev-packer-builds | jq -r '.[] | select(.createdTime < ("2024-12-10")) | .id'`
it's empty which is correct.

if I tried with a date in the future: `az resource list --resource-group=dev-packer-builds | jq -r '.[] | select(.createdTime < ("2024-12-12")) | .id'`
it doest return object from todays builds: 
```
...
/subscriptions/1311c09f-aee0-4d6c-99a4-392c2b543204/resourceGroups/DEV-PACKER-BUILDS/providers/Microsoft.Compute/disks/pkros67wgux1mp3
/subscriptions/1311c09f-aee0-4d6c-99a4-392c2b543204/resourceGroups/dev-packer-builds/providers/Microsoft.Network/networkInterfaces/pkrninzsxr39yye
/subscriptions/1311c09f-aee0-4d6c-99a4-392c2b543204/resourceGroups/dev-packer-builds/providers/Microsoft.Compute/virtualMachines/pkrvmnzsxr39yye
...
```

<img width="1685" alt="Capture d’écran 2024-12-11 à 16 54 18" src="https://github.com/user-attachments/assets/e3db714e-ee7c-4864-92e1-f3c8a19f195b" />
