### PR TITLE
feat(aws) use `gp3` EBS volume

### DIFF
--- a/sources.pkr.hcl
+++ b/sources.pkr.hcl
@@ -11,7 +11,7 @@ source "amazon-ebs" "base" {
     delete_on_termination = true
     device_name           = "/dev/sda1"
     volume_size           = local.windows_disk_size_gb # TODO: check if we can rename this local to cover both windows and Ubuntu
-    volume_type           = "gp2" # TODO: check if we can use `gp3` (blocker was ec2 plugin, not packer)
+    volume_type           = "gp3"
   }
 
 


### PR DESCRIPTION
- It's faster than `gp2` as per https://docs.aws.amazon.com/ebs/latest/userguide/ebs-volume-types.html
- Looks like the current ec2 plugin support gp3 now: https://issues.jenkins.io/browse/JENKINS-73660