### PR TITLE
fix(ubuntu/windows) avoid tragedy of commons goods: use `dlcdn` apache download server for Maven

### DIFF
--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -397,7 +397,7 @@ function install_sops(){
 ## Ensure that maven is installed and configured (version from environment)
 function install_maven() {
   curl --fail --silent --location --show-error --output "/tmp/apache-maven-${MAVEN_VERSION}-bin.tar.gz" \
-    "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz"
+    "https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz"
 
   tar --extract --gunzip --file="/tmp/apache-maven-${MAVEN_VERSION}-bin.tar.gz" --directory=/usr/share/
   ln -s "/usr/share/apache-maven-${MAVEN_VERSION}/bin/mvn" /usr/bin/mvn

--- a/provisioning/windows-provision.ps1
+++ b/provisioning/windows-provision.ps1
@@ -125,7 +125,7 @@ $downloads = [ordered]@{
         'cleanupLocal' = 'true';
     }
     'maven' = @{
-        'url' = 'https://archive.apache.org/dist/maven/maven-3/{0}/binaries/apache-maven-{0}-bin.zip' -f $env:MAVEN_VERSION;
+        'url' = 'https://dlcdn.apache.org/maven/maven-3/{0}/binaries/apache-maven-{0}-bin.zip' -f $env:MAVEN_VERSION;
         'local' = "$baseDir\maven.zip";
         'expandTo' = $baseDir;
         'path' = '{0}\apache-maven-{1}\bin' -f $baseDir,$env:MAVEN_VERSION;


### PR DESCRIPTION
Same as https://github.com/jenkins-infra/github-reusable-workflows/pull/41 + https://github.com/jenkins-infra/github-reusable-workflows/issues/39

We want to avoid the [Tragedy of Common Goods](https://en.wikipedia.org/wiki/Tragedy_of_the_commons) and as such we should only download binaries from the recommended sources.

In the case of Maven, using the Apache CDN instead of archives is the least we can do to decrease our hammering of the Apache public INFRA, and also to decrease chances of failing builds for us.

Note: https://github.com/jenkins-infra/github-reusable-workflows/issues/39#issuecomment-2439796240 shows that there might be "different/better" sources. Worth discussing and changing again, but this PR is a first step.