### PR TITLE
chore(goss/windows): remove retry for goss

### DIFF
--- a/build-jenkins-agent-windows.pkr.hcl
+++ b/build-jenkins-agent-windows.pkr.hcl
@@ -106,9 +106,9 @@ build {
     inline = [
       "$ErrorActionPreference = 'Stop'",
       "goss --version",
-      "goss --use-alpha=1 --gossfile C:/goss-windows-${var.agent_os_version}.yaml --loglevel DEBUG validate --retry-timeout 60s",
-      "goss --use-alpha=1 --gossfile C:/goss-windows.yaml --loglevel DEBUG validate --retry-timeout 60s",
-      "goss --use-alpha=1 --gossfile C:/goss-common.yaml --loglevel DEBUG validate --retry-timeout 60s",
+      "goss --use-alpha=1 --gossfile C:/goss-windows-${var.agent_os_version}.yaml --loglevel DEBUG validate",
+      "goss --use-alpha=1 --gossfile C:/goss-windows.yaml --loglevel DEBUG validate",
+      "goss --use-alpha=1 --gossfile C:/goss-common.yaml --loglevel DEBUG validate",
     ]
   }
 


### PR DESCRIPTION
to avoid a waste of time and process, we reduce the retry time on windows to the default `0` as per https://github.com/goss-org/goss/blob/00e9355293bbe8b554f8b874cced6a55aa92ffd4/docs/cli.md?plain=1#L341