### PR TITLE
chore(tests): move hadolint to goss-common and add specific timeout

### DIFF
--- a/build-jenkins-agent-windows.pkr.hcl
+++ b/build-jenkins-agent-windows.pkr.hcl
@@ -118,7 +118,7 @@ build {
       "goss --version",
       "goss --use-alpha=1 --gossfile C:/goss-windows-${var.agent_os_version}.yaml --loglevel DEBUG validate --max-concurrent=1",
       "goss --use-alpha=1 --gossfile C:/goss-windows.yaml --loglevel DEBUG validate --max-concurrent=1",
-      "goss --use-alpha=1 --gossfile C:/goss-common.yaml --loglevel DEBUG validate --max-concurrent=",
+      "goss --use-alpha=1 --gossfile C:/goss-common.yaml --loglevel DEBUG validate --max-concurrent=1",
       "Remove-Item -Force C:/goss-windows.yaml",
       "Remove-Item -Force C:/goss-common.yaml",
       "Remove-Item -Force C:/visualstudio.vsconfig",

--- a/build-jenkins-agent-windows.pkr.hcl
+++ b/build-jenkins-agent-windows.pkr.hcl
@@ -116,9 +116,9 @@ build {
     inline = [
       "$ErrorActionPreference = 'Stop'",
       "goss --version",
-      "goss --use-alpha=1 --gossfile C:/goss-windows-${var.agent_os_version}.yaml --loglevel DEBUG validate --max-concurrent=4",
-      "goss --use-alpha=1 --gossfile C:/goss-windows.yaml --loglevel DEBUG validate --max-concurrent=4",
-      "goss --use-alpha=1 --gossfile C:/goss-common.yaml --loglevel DEBUG validate --max-concurrent=4",
+      "goss --use-alpha=1 --gossfile C:/goss-windows-${var.agent_os_version}.yaml --loglevel DEBUG validate --max-concurrent=1",
+      "goss --use-alpha=1 --gossfile C:/goss-windows.yaml --loglevel DEBUG validate --max-concurrent=1",
+      "goss --use-alpha=1 --gossfile C:/goss-common.yaml --loglevel DEBUG validate --max-concurrent=",
       "Remove-Item -Force C:/goss-windows.yaml",
       "Remove-Item -Force C:/goss-common.yaml",
       "Remove-Item -Force C:/visualstudio.vsconfig",

--- a/tests/goss-common.yaml
+++ b/tests/goss-common.yaml
@@ -51,6 +51,12 @@ command:
     exit-status: 0
     stdout:
       - 0.4.9
+  hadolint:
+    exec: hadolint --version
+    exit-status: 0
+    stdout:
+      - 2.12.0
+    timeout: 60000
   jq:
     exec: jq --version
     exit-status: 0

--- a/tests/goss-linux.yaml
+++ b/tests/goss-linux.yaml
@@ -37,11 +37,6 @@ command:
     exit-status: 0
     stdout:
       - 1.55.2
-  hadolint:
-    exec: hadolint --version
-    exit-status: 0
-    stdout:
-      - 2.12.0
   helm:
     exec: helm version
     exit-status: 0

--- a/tests/goss-windows.yaml
+++ b/tests/goss-windows.yaml
@@ -31,7 +31,7 @@ command:
     stderr:
       - 1.8.0_432
   maven:
-    exec: pwsh -command "$env:JAVA_HOME='C:\\Program Files (x86)\\jdk-21'; mvn -v"
+    exec: pwsh -command "$env:JAVA_HOME='C:\tools\jdk-21'; mvn -v"
     exit-status: 0
     stdout:
       - 3.9.9


### PR DESCRIPTION
following https://github.com/jenkins-infra/packer-images/pull/1585 we discovered a long time to check hadolint on windows, this timeout should avoid wrong failure for goss.

also reduce max-concurrent to 1 for windows to avoid mistakes on windows goss