### PR TITLE
chore(azcopy/linux): add a version to the apt install of azcopy with the corresponding updatecli manifest

### DIFF
--- a/provisioning/tools-versions.yml
+++ b/provisioning/tools-versions.yml
@@ -1,6 +1,7 @@
 # if manually change, please update the goss file accordingly
 asdf_version: 0.15.0
 awscli_version: 2.22.33
+azcopy_version: 10.27.1
 azurecli_version: 2.67.0
 chocolatey_version: 1.4.0
 compose_version: 2.32.2

--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -457,12 +457,13 @@ function install_azurecli() {
 
 ## Ensure that azcopy is installed
 function install_azcopy() {
-  ## TODO track with updatecli from ../build-jenkins-agent-ubuntu.pkr.hcl
-  curl -sSL -O https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb
-  dpkg -i packages-microsoft-prod.deb
-  rm packages-microsoft-prod.deb
-  apt-get update
-  apt-get install azcopy
+  rep_config_pkg="$(mktemp)"
+  # Download and install the repository configuration package.
+  curl --silent --show-error --location --output "${rep_config_pkg}" https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb
+  dpkg --install "${rep_config_pkg}"
+  rm -f "${rep_config_pkg}"
+  apt-get update --quiet
+  apt-get install --yes --no-install-recommends azcopy="${AZCOPY_VERSION}"
 }
 
 ## Ensure that the GitHub command line (`gh`) is installed

--- a/tests/goss-linux.yaml
+++ b/tests/goss-linux.yaml
@@ -9,6 +9,8 @@ command:
   azcopy:
     exec: azcopy --version
     exit-status: 0
+    stdout:
+      - 10.27.1
   chromium-browser:
     exec: chromium-browser --version
     exit-status: 0

--- a/updatecli/updatecli.d/azcopy.yaml
+++ b/updatecli/updatecli.d/azcopy.yaml
@@ -1,0 +1,53 @@
+---
+name: Bump `azcopy` version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastReleaseVersion:
+    kind: githubrelease
+    name: Get the latest `azcopy` version
+    spec:
+      owner: Azure
+      repository: azure-storage-azcopy
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+    transformers:
+      - trimprefix: 'v'
+
+targets:
+  updateVersion:
+    name: "Update the `azcopy` version in the tools-versions.yml file"
+    sourceid: lastReleaseVersion
+    kind: yaml
+    spec:
+      file: provisioning/tools-versions.yml
+      key: $.azcopy_version
+    scmid: default
+  updateVersionInGoss:
+    name: Update the `azcopy` version in the goss test
+    kind: yaml
+    spec:
+      file: tests/goss-linux.yaml
+      key: $.command.azcopy.stdout[0]
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    title: Bump azcopy version to {{ source "lastReleaseVersion" }}
+    scmid: default
+    spec:
+      labels:
+        - enhancement
+        - azcopy


### PR DESCRIPTION
following #1645 and as per https://github.com/jenkins-infra/helpdesk/issues/4471
this PR lock azcopy install to as specific version and track it with updatecli