### PR TITLE
chore(goss/build-jenkins-agent-windows.pkr) move `max-concurrent` parameter in front

### DIFF
--- a/build-jenkins-agent-windows.pkr.hcl
+++ b/build-jenkins-agent-windows.pkr.hcl
@@ -116,9 +116,9 @@ build {
     inline = [
       "$ErrorActionPreference = 'Stop'",
       "goss --version",
-      "goss --use-alpha=1 --gossfile C:/goss-windows-${var.agent_os_version}.yaml --loglevel DEBUG validate --max-concurrent=1",
-      "goss --use-alpha=1 --gossfile C:/goss-windows.yaml --loglevel DEBUG validate --max-concurrent=1",
-      "goss --use-alpha=1 --gossfile C:/goss-common.yaml --loglevel DEBUG validate --max-concurrent=1",
+      "goss --use-alpha=1 --max-concurrent=1 --gossfile C:/goss-windows-${var.agent_os_version}.yaml --loglevel DEBUG validate",
+      "goss --use-alpha=1 --max-concurrent=1 --gossfile C:/goss-windows.yaml --loglevel DEBUG validate",
+      "goss --use-alpha=1 --max-concurrent=1 --gossfile C:/goss-common.yaml --loglevel DEBUG validate",
       "Remove-Item -Force C:/goss-windows.yaml",
       "Remove-Item -Force C:/goss-common.yaml",
       "Remove-Item -Force C:/visualstudio.vsconfig",


### PR DESCRIPTION
to be sure it's taken in account

as per https://github.com/goss-org/goss/blob/b563479df886927e0bbcbe62dea245ac12d9fb99/cmd/goss/goss.go#L33