### PR TITLE
fix(windows) ensure Git has autoCRLF enabled

### DIFF
--- a/provisioning/windows-provision.ps1
+++ b/provisioning/windows-provision.ps1
@@ -142,7 +142,7 @@ $downloads = [ordered]@{
         'local' = "$baseDir\MinGit.zip";
         'expandTo' = "$baseDir\git";
         'postExpand' = {
-            & "$baseDir\git\cmd\git.exe" config --system core.autocrlf false;
+            & "$baseDir\git\cmd\git.exe" config --system core.autocrlf true;
             & "$baseDir\git\cmd\git.exe" config --system core.longpaths true;
         };
         # git cmd and gnu tools included with git as paths


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3865

This PR applies @jtnord's proposal in https://github.com/jenkins-infra/pipeline-library/pull/899#discussion_r1910892747 to set up tje default autoCRLF for Git.

Note: it was explicitly set to `false` since 5 years (https://github.com/jenkins-infra/packer-images/pull/8). Not sure why, so let's go with the new setting to fix spotless issues *also* in the Windows VM templates