### PR TITLE
feat(windows/ec2) enable Fast Launch with default setup

### DIFF
--- a/build-jenkins-agent-ubuntu.pkr.hcl
+++ b/build-jenkins-agent-ubuntu.pkr.hcl
@@ -14,9 +14,9 @@ build {
     image_offer     = "0001-com-ubuntu-server-jammy"
     image_publisher = "canonical"
     # List available SKUs with the command `az vm image list-skus --offer 0001-com-ubuntu-server-jammy --location eastus --publisher canonical --output table`
-    image_sku = local.az_instance_image_sku[var.architecture]
+    image_sku     = local.az_instance_image_sku[var.architecture]
     image_version = try(local.images_versions["azure"][var.agent_os_type][var.agent_os_version][var.architecture], "N/A")
-    os_type   = "Linux"
+    os_type       = "Linux"
   }
 
   provisioner "shell" {

--- a/build-jenkins-agent-windows.pkr.hcl
+++ b/build-jenkins-agent-windows.pkr.hcl
@@ -67,8 +67,8 @@ build {
   }
 
   provisioner "file" {
-    source       = "./provisioning/visualstudio.vsconfig"
-    destination  = "C:/"
+    source      = "./provisioning/visualstudio.vsconfig"
+    destination = "C:/"
   }
 
   provisioner "powershell" {

--- a/build-jenkins-agent-windows.pkr.hcl
+++ b/build-jenkins-agent-windows.pkr.hcl
@@ -7,6 +7,10 @@ build {
     winrm_timeout  = "20m"
     winrm_use_ssl  = true
     winrm_username = local.windows_winrm_user[var.image_type]
+
+    fast_launch {
+      enable_fast_launch = true
+    }
   }
 
   source "azure-arm.base" {

--- a/locals.pkr.hcl
+++ b/locals.pkr.hcl
@@ -16,8 +16,8 @@ locals {
     "arm64" = "${local.agent_os_version_safe}-lts-arm64"
   }
   windows_winrm_user = {
-    "azure-arm" = "packer"
-    "docker"    = "packer"
+    "azure-arm"  = "packer"
+    "docker"     = "packer"
     "amazon-ebs" = "Administrator" # In AWS EC2, WinRM super admin must be the "Administrator" account
   }
 

--- a/sources.pkr.hcl
+++ b/sources.pkr.hcl
@@ -18,10 +18,10 @@ source "amazon-ebs" "base" {
   # Enforce IMDS v2 as per https://aws.amazon.com/blogs/security/get-the-full-benefits-of-imdsv2-and-disable-imdsv1-across-your-aws-infrastructure/
   imds_support = "v2.0"
   metadata_options {
-    http_endpoint = "enabled"
-    http_tokens = "required"
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
     http_put_response_hop_limit = 1 # Do not allow access to IMDS through NAT-ed containers
-    instance_metadata_tags = "disabled"
+    instance_metadata_tags      = "disabled"
   }
 
   # Where to export the AMI

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -15,7 +15,7 @@ variable "architecture" {
 }
 variable "aws_destination_region" {
   type    = string
-  default = env("AWS_DEFAULT_REGION")   # Defaults to the only region we use
+  default = env("AWS_DEFAULT_REGION") # Defaults to the only region we use
 }
 variable "azure_client_id" {
   type    = string


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4316

This PR enables [EC2 Fast Launch](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/win-ami-config-fast-launch.html) for the EC2 Windows templates.

The goal is to ensure faster boot of Windows VM agents