### PR TITLE
feat(aws-cli/pinned): add a pinned version 2.22.35 for aws-cli

### DIFF
--- a/provisioning/tools-versions.yml
+++ b/provisioning/tools-versions.yml
@@ -1,6 +1,6 @@
 # if manually change, please update the goss file accordingly
 asdf_version: 0.15.0
-awscli_version: 2.23.6
+awscli_version: 2.23.13
 awscli_pinned_version: 2.22.35
 azcopy_version: 10.28.0
 azurecli_version: 2.68.0

--- a/provisioning/tools-versions.yml
+++ b/provisioning/tools-versions.yml
@@ -1,6 +1,7 @@
 # if manually change, please update the goss file accordingly
 asdf_version: 0.15.0
-awscli_version: 2.23.13
+awscli_version: 2.23.6
+awscli_pinned_version: 2.22.35
 azcopy_version: 10.28.0
 azurecli_version: 2.68.0
 chocolatey_version: 1.4.0

--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -553,30 +553,27 @@ function install_updatecli() {
 function install_awscli() {
   local archive_path download_url
   archive_path=/tmp/awscli.zip
-  download_url="https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWSCLI_VERSION}.zip"
+  # check if a version argument is provided
+  if [ -n "$1" ]; then
+    local VERSION="$1"
+  else
+    # else use the AWSCLI_VERSION tracked with updatecli
+    local VERSION="${AWSCLI_VERSION}"
+  fi
+  download_url="https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${VERSION}.zip"
   if test "${ARCHITECTURE}" == "arm64"
   then
-    download_url="https://awscli.amazonaws.com/awscli-exe-linux-aarch64-${AWSCLI_VERSION}.zip"
+    download_url="https://awscli.amazonaws.com/awscli-exe-linux-aarch64-${VERSION}.zip"
   fi
   curl --silent --location --show-error "${download_url}" --output "${archive_path}"
   unzip "${archive_path}" -d /tmp
-  bash /tmp/aws/install
-  rm -rf /tmp/aws*
-}
-# https://github.com/jenkins-infra/packer-images/pull/1676 usage by directly calling /usr/local/aws-cli-${AWSCLI_PINNED_VERSION}/aws
-function install_pinned_awscli() {
-  local archive_path download_url install_dir bin_dir
-  archive_path=/tmp/awscli.zip
-  download_url="https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWSCLI_PINNED_VERSION}.zip"
-  install_dir="/usr/local/aws-cli-${AWSCLI_PINNED_VERSION}/"
-  bin_dir="${install_dir}"
-  if test "${ARCHITECTURE}" == "arm64"
-  then
-    download_url="https://awscli.amazonaws.com/awscli-exe-linux-aarch64-${AWSCLI_PINNED_VERSION}.zip"
+  if [ -n "$1" ]; then
+    local install_dir
+    install_dir="/usr/local/aws-cli-${VERSION}/"
+    bash /tmp/aws/install --install-dir "${install_dir}" --bin-dir "${install_dir}"
+  else
+    bash /tmp/aws/install
   fi
-  curl --silent --location --show-error "${download_url}" --output "${archive_path}"
-  unzip "${archive_path}" -d /tmp
-  bash /tmp/aws/install --install-dir "${install_dir}" --bin-dir "${bin_dir}"
   rm -rf /tmp/aws*
 }
 
@@ -740,7 +737,7 @@ function main() {
   install_packer
   install_updatecli
   install_awscli
-  install_pinned_awscli
+  install_awscli "${AWSCLI_PINNED_VERSION}"
   install_netlifydeploy
   install_terraform
   install_kubectl

--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -550,25 +550,25 @@ function install_updatecli() {
 }
 
 # https://docs.aws.amazon.com/cli/latest/userguide/getting-started-version.html
+# if called with a parameter, the specified version will be installed in the folder: /usr/local/aws-cli-${VERSION}/
+# but not included in the path
+# if called without parameters, the install will be done on the version ${AWSCLI_VERSION} and accessible in the PATH
 function install_awscli() {
   local archive_path download_url
   archive_path=/tmp/awscli.zip
-  # check if a version argument is provided
   if [ -n "$1" ]; then
     local VERSION="$1"
   else
-    # else use the AWSCLI_VERSION tracked with updatecli
     local VERSION="${AWSCLI_VERSION}"
   fi
-  download_url="https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${VERSION}.zip"
-  if test "${ARCHITECTURE}" == "arm64"
-  then
-    download_url="https://awscli.amazonaws.com/awscli-exe-linux-aarch64-${VERSION}.zip"
-  fi
+  download_url="https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m)-${VERSION}.zip"
   curl --silent --location --show-error "${download_url}" --output "${archive_path}"
   unzip "${archive_path}" -d /tmp
   if [ -n "$1" ]; then
     local install_dir
+
+    # we define install-dir and bin-dir to be able to install multiple versions of AWS and have only the default one in the PATH
+    # we use the same value for install-dir and bin-dir to make sure that the pinned version is within the dedicated folder
     install_dir="/usr/local/aws-cli-${VERSION}/"
     bash /tmp/aws/install --install-dir "${install_dir}" --bin-dir "${install_dir}"
   else

--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -563,6 +563,22 @@ function install_awscli() {
   bash /tmp/aws/install
   rm -rf /tmp/aws*
 }
+# https://github.com/jenkins-infra/packer-images/pull/1676 usage by directly calling /usr/local/aws-cli-${AWSCLI_PINNED_VERSION}/aws
+function install_pinned_awscli() {
+  local archive_path download_url install_dir bin_dir
+  archive_path=/tmp/awscli.zip
+  download_url="https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWSCLI_PINNED_VERSION}.zip"
+  install_dir="/usr/local/aws-cli-${AWSCLI_PINNED_VERSION}/"
+  bin_dir="${install_dir}"
+  if test "${ARCHITECTURE}" == "arm64"
+  then
+    download_url="https://awscli.amazonaws.com/awscli-exe-linux-aarch64-${AWSCLI_PINNED_VERSION}.zip"
+  fi
+  curl --silent --location --show-error "${download_url}" --output "${archive_path}"
+  unzip "${archive_path}" -d /tmp
+  bash /tmp/aws/install --install-dir "${install_dir}" --bin-dir "${bin_dir}"
+  rm -rf /tmp/aws*
+}
 
 function install_netlifydeploy() {
   local archive_path download_url
@@ -724,6 +740,7 @@ function main() {
   install_packer
   install_updatecli
   install_awscli
+  install_pinned_awscli
   install_netlifydeploy
   install_terraform
   install_kubectl

--- a/tests/goss-linux.yaml
+++ b/tests/goss-linux.yaml
@@ -6,6 +6,11 @@ command:
     exit-status: 0
     stdout:
       - v0.15.0
+  awscli-pinned:
+    exec: /usr/local/aws-cli-2.22.35/aws --version
+    exit-status: 0
+    stdout:
+      - 2.22.35
   azcopy:
     exec: azcopy --version
     exit-status: 0


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4500#issuecomment-2616638933
and following https://github.com/jenkins-infra/packer-images/pull/1676

we now provide 2 versions of aws cli, the default one following the latest with updatecli and a 2.22.35 version that can be called with `/usr/local/aws-cli-2.22.35/aws --version`

ref https://github.com/jenkins-infra/helpdesk/issues/4500#issuecomment-2616638933