### PR TITLE
fix(windows/AWS) correct path to the `EC2Launch.exe` command

### DIFF
--- a/build-jenkins-agent-windows.pkr.hcl
+++ b/build-jenkins-agent-windows.pkr.hcl
@@ -147,8 +147,8 @@ build {
     elevated_password = build.Password
 
     inline = [
-      "& 'C:/Program Files/Amazon/EC2Launch/ec2launch' reset --block",
-      "& 'C:/Program Files/Amazon/EC2Launch/ec2launch' sysprep --block",
+      "& \"$env:ProgramFiles/Amazon/EC2Launch/EC2Launch.exe\" reset --block",
+      "& \"$env:ProgramFiles/Amazon/EC2Launch/EC2Launch.exe\" sysprep --block",
     ]
   }
 }

--- a/build-jenkins-agent-windows.pkr.hcl
+++ b/build-jenkins-agent-windows.pkr.hcl
@@ -147,8 +147,8 @@ build {
     elevated_password = build.Password
 
     inline = [
-      "& \"$env:ProgramFiles/Amazon/EC2Launch/EC2Launch.exe\" reset --block",
-      "& \"$env:ProgramFiles/Amazon/EC2Launch/EC2Launch.exe\" sysprep --block",
+      "& \"$env:ProgramFiles/amazon/ec2launch/ec2launch.exe\" reset --block",
+      "& \"$env:ProgramFiles/amazon/ec2launch/ec2launch.exe\" sysprep --block",
     ]
   }
 }


### PR DESCRIPTION
Since a few days, we start seeing Windows 2019 provisioning failures on AWS (not sure when did it start and it is correlated to a base image change).

The error is the following:

```
amazon-ebs.windows: & : The term 'C:/Program Files/Amazon/EC2Launch/ec2launch' is not recognized as the name of a cmdlet, function, script[0m
amazon-ebs.windows: file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct[0m
amazon-ebs.windows: and try again.[0m
amazon-ebs.windows: At C:\Windows\Temp\script-679a67f3-a287-b936-7f69-b05522aa0c7e.ps1:1 char:3[0m
amazon-ebs.windows: + & 'C:/Program Files/Amazon/EC2Launch/ec2launch' reset --block[0m
amazon-ebs.windows: +   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~[0m
amazon-ebs.windows:     + CategoryInfo          : ObjectNotFound: (C:/Program File...aunch/ec2launch:String) [], CommandNotFoundException[0m
amazon-ebs.windows:     + FullyQualifiedErrorId : CommandNotFoundException[0m
amazon-ebs.windows:[0m
amazon-ebs.windows: & : The term 'C:/Program Files/Amazon/EC2Launch/ec2launch' is not recognized as the name of a cmdlet, function, script[0m
amazon-ebs.windows: file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct[0m
amazon-ebs.windows: and try again.[0m
amazon-ebs.windows: At C:\Windows\Temp\script-679a67f3-a287-b936-7f69-b05522aa0c7e.ps1:2 char:3[0m
amazon-ebs.windows: + & 'C:/Program Files/Amazon/EC2Launch/ec2launch' sysprep --block[0m
amazon-ebs.windows: +   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~[0m
amazon-ebs.windows:     + CategoryInfo          : ObjectNotFound: (C:/Program File...aunch/ec2launch:String) [], CommandNotFoundException[0m
amazon-ebs.windows:     + FullyQualifiedErrorId : CommandNotFoundException[0m
amazon-ebs.windows:[0m
```

This PR follows up the `EC2Launch` documentation at https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2launch-v2-install.html which states:

> 4. The msiexec command installs EC2Launch v2 in the following location on Windows Server instances: %ProgramFiles%\Amazon\EC2Launch. To verify that the install ran, you can check the local file system on your instance.



https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ami-create-win-sysprep.html