### PR TITLE
Revert "Bump aws `windows 2019 AMD64` AMI ID"

### DIFF
--- a/images-versions.yaml
+++ b/images-versions.yaml
@@ -16,7 +16,7 @@ aws:
       arm64: ami-0ea2a0c0dd4236d25
   windows:
     "2019":
-      amd64: ami-0b2e357a8fb7fd019
+      amd64: ami-08b54f8d132ebd12d
     "2022":
       amd64: ami-01e3d0e535b887a71
 docker:


### PR DESCRIPTION
Reverts jenkins-infra/packer-images#1697

Testing if reverting helps fixing https://github.com/jenkins-infra/packer-images/pull/1702