### PR TITLE
chore(updatecli): change ami line for AWS windows 2019 to hove EC2 Launch V2 pre-installed

### DIFF
--- a/updatecli/updatecli.d/windows-2019-aws-images.yaml
+++ b/updatecli/updatecli.d/windows-2019-aws-images.yaml
@@ -23,7 +23,7 @@ sources:
           --owners amazon \
           --filters \
             "Name=platform,Values=windows" \
-            "Name=description,Values=Microsoft Windows Server 2019 Core Locale English AMI provided by Amazon" \
+            "Name=description,Values=Microsoft Windows Server 2019 Core with EC2LaunchV2, English locale AMI provided by Amazon" \
             "Name=root-device-type,Values=ebs" \
             "Name=virtualization-type,Values=hvm" \
             "Name=architecture,Values=x86_64" \

--- a/updatecli/updatecli.d/windows-2019-aws-images.yaml
+++ b/updatecli/updatecli.d/windows-2019-aws-images.yaml
@@ -23,7 +23,7 @@ sources:
           --owners amazon \
           --filters \
             "Name=platform,Values=windows" \
-            "Name=description,Values=Microsoft Windows Server 2019 Core with EC2LaunchV2, English locale AMI provided by Amazon" \
+            "Name=description,Values=Microsoft Windows Server 2019 Core with EC2LaunchV2\, English locale AMI provided by Amazon" \
             "Name=root-device-type,Values=ebs" \
             "Name=virtualization-type,Values=hvm" \
             "Name=architecture,Values=x86_64" \


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4565
the fast launch failed because of the sysprep step failing.
Those AMI got the correct command pre-installed.