### PR TITLE
chore(updatecli/python) add a condition to check for 'Package Approved' on chocolatey

### DIFF
--- a/updatecli/updatecli.d/python3.yml
+++ b/updatecli/updatecli.d/python3.yml
@@ -1,5 +1,5 @@
 ---
-name: Bump python3 version
+name: Bump python3 version for windows
 
 scms:
   default:
@@ -29,6 +29,9 @@ conditions:
     disablesourceinput: true # Do not pass source as argument to the command line
     spec:
       command: curl https://community.chocolatey.org/packages/python3/{{ source "lastReleaseVersion" }} --silent --show-error --location --fail --output /dev/null
+    transformers:
+      - findsubmatch:
+          pattern: 'Package Approved'
 
 targets:
   updateVersion:


### PR DESCRIPTION
The latest version `3.13.2` cannot be installed as it's still under moderation: 
https://community.chocolatey.org/packages/python3/3.13.2

```
IMPORTANT

This version is in [moderation](https://docs.chocolatey.org/en-us/faqs#what-is-moderation) and has not yet been approved. This means it doesn't show up under normal search.

    Until approved, you should consider this package version unsafe - it could do very bad things to your system (it probably doesn't but you have been warned, that's why we have moderation).
    This package version can change wildly over the course of moderation until it is approved. If you install it and it later has changes to this version, you will be out of sync with any changes that have been made to the package. Until approved, you should consider that this package version doesn't even exist.
    You cannot install this package under normal scenarios. See [How to install package version under moderation](https://docs.chocolatey.org/en-us/faqs#how-do-i-install-a-package-version-under-moderation) for more information.
    There are also no guarantees that it will be approved.
 ```