### PR TITLE
Revert "fix(windows): set the default encoding to utf-8"

### DIFF
--- a/provisioning/windows-provision.ps1
+++ b/provisioning/windows-provision.ps1
@@ -14,6 +14,7 @@ Set-ExecutionPolicy -Scope Process -ExecutionPolicy Unrestricted -Force
 Add-Type -AssemblyName System.Web
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
+
 ## Reusable Functions (must be declared before calling)
 Function Retry-Command {
     [CmdletBinding()]
@@ -63,10 +64,6 @@ Function AddToPathEnv($path) {
     $newPath = '{0};{1}' -f $path,$oldPath
     Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value $newPath | Out-Null
 }
-
-# Set UTF8 as default
-[System.Console]::OutputEncoding = [System.Console]::InputEncoding = [System.Text.Encoding]::UTF8
-$PSDefaultParameterValues['*:Encoding'] = 'utf8'
 
 # Install OpenSSH (from Windows Features)
 Write-Output "= Installing OpenSSH Server..."


### PR DESCRIPTION
Reverts jenkins-infra/packer-images#1783

as it is not working, lets remove this and try in the cloudinit/initscript 