### PR TITLE
revert[git/windows] revert version from 2.48.1 to 2.47.1

### DIFF
--- a/provisioning/tools-versions.yml
+++ b/provisioning/tools-versions.yml
@@ -12,7 +12,7 @@ doctl_version: 1.123.0
 gh_version: 2.67.0
 git_lfs_version: 3.6.1
 git_linux_version: 2.48.1
-git_windows_version: 2.48.1
+git_windows_version: 2.47.1
 golang_version: 1.24.1
 golangcilint_version: 1.55.2
 goss_version: 0.4.9


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4574\#issuecomment-2703350642

reverting git on windows to 2.47.1