### PR TITLE
fix(Windows/git) Ensure Git LongPath is set at system level

### DIFF
--- a/provisioning/windows-provision.ps1
+++ b/provisioning/windows-provision.ps1
@@ -145,8 +145,8 @@ $downloads = [ordered]@{
         'local' = "$baseDir\MinGit.zip";
         'expandTo' = "$baseDir\git";
         'postExpand' = {
-            & "$baseDir\git\cmd\git.exe" config --system core.autocrlf true;
-            & "$baseDir\git\cmd\git.exe" config --system core.longpaths true;
+            & "$baseDir\git\cmd\git.exe" config set --system core.autocrlf "true";
+            & "$baseDir\git\cmd\git.exe" config set --system core.longPaths "true";
         };
         # git cmd and gnu tools included with git as paths
         'path' = "$baseDir\git\cmd;$baseDir\git\usr\bin";


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4574

Twin of https://github.com/jenkins-infra/pipeline-library/pull/914