### PR TITLE
chore(updatecli) track kubectl `1.31.x` line instead of `1.30.x`

### DIFF
--- a/updatecli/updatecli.d/kubectl.yaml
+++ b/updatecli/updatecli.d/kubectl.yaml
@@ -26,7 +26,7 @@ sources:
       username: "{{ .github.username }}"
       versionfilter:
         kind: regex
-        pattern: "^kubernetes-1.30.(\\d*)$"
+        pattern: "^kubernetes-1.31.(\\d*)$"
 
 targets:
   updateVersion:


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4546