### PR TITLE
chore(GHA) use Ubuntu latest runners on Release Drafter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 jobs:
   update_release_draft:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v5
         env:


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/2982