### PR TITLE
chore(Jenkinsfile_updatecli) abort previous builds and other good practises

### DIFF
--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -1,9 +1,22 @@
-withCredentials([
-    azureServicePrincipal('updatecli-azure-serviceprincipal'),
-]) {
-    if (env.BRANCH_IS_PRIMARY) {
-        updatecli(action: 'apply', updatecliAgentLabel: 'linux-amd64-docker', cronTriggerExpression: '@daily')
-    } else {
-        updatecli(action: 'diff', updatecliAgentLabel: 'linux-amd64-docker')
+final String cronExpr = env.BRANCH_IS_PRIMARY ? '@daily' : ''
+
+properties([
+    buildDiscarder(logRotator(numToKeepStr: '10')),
+    disableConcurrentBuilds(abortPrevious: true),
+    pipelineTriggers([cron(cronExpr)]),
+])
+
+final String updatecliAction = env.BRANCH_IS_PRIMARY ? 'apply' : 'diff'
+
+timeout(time: 10, unit: 'MINUTES') {
+    withCredentials([
+        azureServicePrincipal('updatecli-azure-serviceprincipal'),
+    ]) {
+        stage("Run updatecli action: ${updatecliAction}") {
+            updatecli(
+                action: updatecliAction,
+                updatecliAgentLabel: 'linux-amd64-docker', // we need a VM with Docker
+            )
+        }
     }
 }


### PR DESCRIPTION
Same updatecli pipeline options as https://github.com/jenkins-infra/docker-404/pull/42

Should remove the orphan `updatecli_*` branches