### PR TITLE
fix(ubuntu) use `azcopy` debian package from GH release to circumvent Microsoft Azcopy package errors

### DIFF
--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -458,13 +458,15 @@ function install_azurecli() {
 
 ## Ensure that azcopy is installed
 function install_azcopy() {
-  rep_config_pkg="$(mktemp)"
-  # Download and install the repository configuration package.
-  curl --silent --show-error --location --output "${rep_config_pkg}" https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb
-  dpkg --install "${rep_config_pkg}"
-  rm -f "${rep_config_pkg}"
-  apt-get update --quiet
-  apt-get install --yes --no-install-recommends azcopy="${AZCOPY_VERSION}"
+  azcopy_arch="$(uname -m)"
+  if [ "${azcopy_arch}" == "aarch64" ]
+  then
+    azcopy_arch="arm64"
+  fi
+  azcopy_pkg="$(mktemp)"
+  curl --silent --show-error --location --output "${azcopy_pkg}" "https://github.com/Azure/azure-storage-azcopy/releases/download/v${AZCOPY_VERSION}/azcopy-${AZCOPY_VERSION}.${azcopy_arch}.deb"
+  dpkg --install "${azcopy_pkg}"
+  rm -f "${azcopy_pkg}"
 }
 
 ## Ensure that the GitHub command line (`gh`) is installed

--- a/updatecli/updatecli.d/azcopy.yaml
+++ b/updatecli/updatecli.d/azcopy.yaml
@@ -25,6 +25,18 @@ sources:
     transformers:
       - trimprefix: 'v'
 
+conditions:
+  checkx86DebPackage:
+    kind: file
+    disablesourceinput: true
+    spec:
+      file: https://github.com/Azure/azure-storage-azcopy/releases/download/v{{ source "lastReleaseVersion" }}/azcopy-{{ source "lastReleaseVersion" }}.x86_64.deb
+  checkArm64DebPackage:
+    kind: file
+    disablesourceinput: true
+    spec:
+      file: https://github.com/Azure/azure-storage-azcopy/releases/download/v{{ source "lastReleaseVersion" }}/azcopy-{{ source "lastReleaseVersion" }}.arm64.deb
+
 targets:
   updateVersion:
     name: "Update the `azcopy` version in the tools-versions.yml file"


### PR DESCRIPTION
Since 48h, the installation of `azcopy` fails with the following error:

```bash
$ apt-get install --yes --no-install-recommends azcopy=10.29.0
Reading package lists...
azure-arm.ubuntu: Building dependency tree...
Reading state information...
Package azcopy is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or is only available from another source
E: Version '10.29.0' for 'azcopy' was not found
```

The package 10.29.0 is not available anymore in the repository. It worked the day before but not anymore.

This PR is a fix which uses the debian packages from the AzCopy GitHub releases (which we use as source for the updatecli version tracking) which are available for both x86_64 and arm64.

We loose the checksum check of the download (but it's HTTPS so not a security issue, more a safety issue of corrupted file) but it's a tradeoff.