### PR TITLE
Add Server-Media-Foundation as part of the Windows provisioning script

### DIFF
--- a/provisioning/windows-provision.ps1
+++ b/provisioning/windows-provision.ps1
@@ -65,6 +65,9 @@ Function AddToPathEnv($path) {
     Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value $newPath | Out-Null
 }
 
+# Requried by testing libraries such as playwright
+Install-WindowsFeature Server-Media-Foundation
+
 # Install OpenSSH (from Windows Features)
 Write-Output "= Installing OpenSSH Server..."
 Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0


### PR DESCRIPTION
Adding the Server-Media-Foundation functionality to remove warnings from the playwright testing framework

See https://github.com/jenkinsci/pipeline-graph-view-plugin/pull/761#issuecomment-2883249548 
