### PR TITLE
chore(updatecli): track new versions by os and architecture for jdks

### DIFF
--- a/jdks_infos.yaml
+++ b/jdks_infos.yaml
@@ -1,0 +1,54 @@
+---
+linux:
+  x64:
+    jdk8:
+      installer_url: https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u452-b09/OpenJDK8U-jdk_x64_linux_hotspot_8u452b09.tar.gz
+      release_name: jdk8u452-b09
+      checksum_url: https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u452-b09/OpenJDK8U-jdk_x64_linux_hotspot_8u452b09.tar.gz.sha256.txt
+    jdk11:
+      installer_url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.27%2B6/OpenJDK11U-jdk_x64_linux_hotspot_11.0.27_6.tar.gz
+      release_name: jdk-11.0.27+6
+      checksum_url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.27%2B6/OpenJDK11U-jdk_x64_linux_hotspot_11.0.27_6.tar.gz.sha256.txt
+    jdk17:
+      installer_url: https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.15%2B6/OpenJDK17U-jdk_x64_linux_hotspot_17.0.15_6.tar.gz
+      release_name: jdk-17.0.15+6
+      checksum_url: https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.15%2B6/OpenJDK17U-jdk_x64_linux_hotspot_17.0.15_6.tar.gz.sha256.txt
+    jdk21:
+      installer_url: https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.7%2B6/OpenJDK21U-jdk_x64_linux_hotspot_21.0.7_6.tar.gz
+      release_name: jdk-21.0.7+6
+      checksum_url: https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.7%2B6/OpenJDK21U-jdk_x64_linux_hotspot_21.0.7_6.tar.gz.sha256.txt
+  aarch64:
+    jdk8:
+      installer_url: https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u452-b09/OpenJDK8U-jdk_aarch64_linux_hotspot_8u452b09.tar.gz
+      release_name: jdk8u452-b09
+      checksum_url: https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u452-b09/OpenJDK8U-jdk_aarch64_linux_hotspot_8u452b09.tar.gz.sha256.txt
+    jdk11:
+      installer_url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.27%2B6/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.27_6.tar.gz
+      release_name: jdk-11.0.27+6
+      checksum_url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.27%2B6/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.27_6.tar.gz.sha256.txt
+    jdk17:
+      installer_url: https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.15%2B6/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.15_6.tar.gz
+      release_name: jdk-17.0.15+6
+      checksum_url: https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.15%2B6/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.15_6.tar.gz.sha256.txt
+    jdk21:
+      installer_url: https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.7%2B6/OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.7_6.tar.gz
+      release_name: jdk-21.0.7+6
+      checksum_url: https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.7%2B6/OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.7_6.tar.gz.sha256.txt
+windows:
+  x64:
+    jdk8:
+      installer_url: https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u452-b09/OpenJDK8U-jdk_x64_windows_hotspot_8u452b09.zip
+      release_name: jdk8u452-b09
+      checksum_url: https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u452-b09/OpenJDK8U-jdk_x64_windows_hotspot_8u452b09.zip.sha256.txt
+    jdk11:
+      installer_url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.27%2B6/OpenJDK11U-jdk_x64_windows_hotspot_11.0.27_6.zip
+      release_name: jdk-11.0.27+6
+      checksum_url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.27%2B6/OpenJDK11U-jdk_x64_windows_hotspot_11.0.27_6.zip.sha256.txt
+    jdk17:
+      installer_url: https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.15%2B6/OpenJDK17U-jdk_x64_windows_hotspot_17.0.15_6.zip
+      release_name: jdk-17.0.15+6
+      checksum_url: https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.15%2B6/OpenJDK17U-jdk_x64_windows_hotspot_17.0.15_6.zip.sha256.txt
+    jdk21:
+      installer_url: https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.7%2B6/OpenJDK21U-jdk_x64_windows_hotspot_21.0.7_6.zip
+      release_name: jdk-21.0.7+6
+      checksum_url: https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.7%2B6/OpenJDK21U-jdk_x64_windows_hotspot_21.0.7_6.zip.sha256.txt

--- a/jdks_infos.yaml
+++ b/jdks_infos.yaml
@@ -1,54 +1,66 @@
 ---
-linux:
-  x64:
+ubuntu:
+  amd64:
     jdk8:
       installer_url: https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u452-b09/OpenJDK8U-jdk_x64_linux_hotspot_8u452b09.tar.gz
-      release_name: jdk8u452-b09
+      release_name: 8u452-b09
       checksum_url: https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u452-b09/OpenJDK8U-jdk_x64_linux_hotspot_8u452b09.tar.gz.sha256.txt
+      checksum_value: 9448308a21841960a591b47927cf2d44fdc4c0533a5f8111a4b243a6bafb5d27
     jdk11:
       installer_url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.27%2B6/OpenJDK11U-jdk_x64_linux_hotspot_11.0.27_6.tar.gz
-      release_name: jdk-11.0.27+6
+      release_name: 11.0.27+6
       checksum_url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.27%2B6/OpenJDK11U-jdk_x64_linux_hotspot_11.0.27_6.tar.gz.sha256.txt
+      checksum_value: dc6136eaa8c1898cbf8973bb1e203e1f653f4c9166be0f5bebe0b02c5f3b5ae3
     jdk17:
       installer_url: https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.15%2B6/OpenJDK17U-jdk_x64_linux_hotspot_17.0.15_6.tar.gz
-      release_name: jdk-17.0.15+6
+      release_name: 17.0.15+6
       checksum_url: https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.15%2B6/OpenJDK17U-jdk_x64_linux_hotspot_17.0.15_6.tar.gz.sha256.txt
+      checksum_value: 9616877c733c9249328ea9bd83a5c8c30e0f9a7af180cac8ffda9034161c2df2
     jdk21:
       installer_url: https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.7%2B6/OpenJDK21U-jdk_x64_linux_hotspot_21.0.7_6.tar.gz
-      release_name: jdk-21.0.7+6
+      release_name: 21.0.7+6
       checksum_url: https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.7%2B6/OpenJDK21U-jdk_x64_linux_hotspot_21.0.7_6.tar.gz.sha256.txt
-  aarch64:
+      checksum_value: 974d3acef0b7193f541acb61b76e81670890551366625d4f6ca01b91ac152ce0
+  arm64:
     jdk8:
       installer_url: https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u452-b09/OpenJDK8U-jdk_aarch64_linux_hotspot_8u452b09.tar.gz
-      release_name: jdk8u452-b09
+      release_name: 8u452-b09
       checksum_url: https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u452-b09/OpenJDK8U-jdk_aarch64_linux_hotspot_8u452b09.tar.gz.sha256.txt
+      checksum_value: d8a1aecea0913b7a1e0d737ba6f7ea99059b3f6fd17813d4a24e8b3fc3aee278
     jdk11:
       installer_url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.27%2B6/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.27_6.tar.gz
-      release_name: jdk-11.0.27+6
+      release_name: 11.0.27+6
       checksum_url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.27%2B6/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.27_6.tar.gz.sha256.txt
+      checksum_value: 4decd2e5caf4667144091cf723458b14148dc990730b3ecb34bba5eb1aa4ad5d
     jdk17:
       installer_url: https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.15%2B6/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.15_6.tar.gz
-      release_name: jdk-17.0.15+6
+      release_name: 17.0.15+6
       checksum_url: https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.15%2B6/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.15_6.tar.gz.sha256.txt
+      checksum_value: 0db0d6cbe33238f33aa52837b1dc8fc6067b34d206b3e0f9243c7f8c9b9539a5
     jdk21:
       installer_url: https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.7%2B6/OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.7_6.tar.gz
-      release_name: jdk-21.0.7+6
+      release_name: 21.0.7+6
       checksum_url: https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.7%2B6/OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.7_6.tar.gz.sha256.txt
+      checksum_value: 31dba70ba928c78c20d62049ac000f79f7a7ab11f9d9c11e703f52d60aa64f93
 windows:
-  x64:
+  amd64:
     jdk8:
       installer_url: https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u452-b09/OpenJDK8U-jdk_x64_windows_hotspot_8u452b09.zip
-      release_name: jdk8u452-b09
+      release_name: 8u452-b09
       checksum_url: https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u452-b09/OpenJDK8U-jdk_x64_windows_hotspot_8u452b09.zip.sha256.txt
+      checksum_value: 732f9e6015d6b0996ec5bae7e824996843295b366ea734557a158d87a7b8845b
     jdk11:
       installer_url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.27%2B6/OpenJDK11U-jdk_x64_windows_hotspot_11.0.27_6.zip
-      release_name: jdk-11.0.27+6
+      release_name: 11.0.27+6
       checksum_url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.27%2B6/OpenJDK11U-jdk_x64_windows_hotspot_11.0.27_6.zip.sha256.txt
+      checksum_value: 8503478995c81926db7154e3fbf3fce3ea214b1062c0a3391db52b0798640f5c
     jdk17:
       installer_url: https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.15%2B6/OpenJDK17U-jdk_x64_windows_hotspot_17.0.15_6.zip
-      release_name: jdk-17.0.15+6
+      release_name: 17.0.15+6
       checksum_url: https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.15%2B6/OpenJDK17U-jdk_x64_windows_hotspot_17.0.15_6.zip.sha256.txt
+      checksum_value: 118cf8d586ee3200e2d2e6e49717db4fb1a22005700fbf85f06166046ec74863
     jdk21:
       installer_url: https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.7%2B6/OpenJDK21U-jdk_x64_windows_hotspot_21.0.7_6.zip
-      release_name: jdk-21.0.7+6
+      release_name: 21.0.7+6
       checksum_url: https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.7%2B6/OpenJDK21U-jdk_x64_windows_hotspot_21.0.7_6.zip.sha256.txt
+      checksum_value: 38f4b9fa0b36def9812f6576fd45f6224630477db8c4e669ee78eaa35abb9195

--- a/locals.pkr.hcl
+++ b/locals.pkr.hcl
@@ -43,4 +43,6 @@ locals {
       "LC_ALL=${var.locale}",
     ],
   )
+
+  jdks_infos = yamldecode(file("./jdks_infos.yaml"))
 }

--- a/updatecli/updatecli.d/jdks.yml
+++ b/updatecli/updatecli.d/jdks.yml
@@ -1,6 +1,7 @@
 {{ range $item := .jdks }}
 {{ $major := $item.major }}
 {{ $releasetype := default "ga" $item.releasetype }}
+{{ $platforms := default "ubuntu/amd64 ubuntu/arm64 windows/amd64" $item.releasetype }}
 ---
 name: Bump JDK '{{ $major }}' version
 
@@ -24,50 +25,61 @@ sources:
       releasetype: {{ $releasetype }}
     transformers:
       - trimprefix: "jdk{{ if (ne $major 8) }}-{{ end }}"
-{{ range $platform := $.platforms }}
-{{ $arch := $platform.arch}}
-{{ $os := $platform.os }}
-  {{ $os }}_{{ $arch }}_release_name:
-    kind: temurin
-    spec:
-      featureversion: {{ $major }}
-      releasetype: {{ $releasetype }}
-      result: version
-      operatingsystem: {{ $os }}
-      architecture: {{ $arch}}
-  {{ $os }}_{{ $arch }}_installer_url:
-    kind: temurin
-    spec:
-      featureversion: {{ $major }}
-      releasetype: {{ $releasetype }}
-      result: installer_url
-      operatingsystem: {{ $os }}
-      architecture: {{ $arch}}
+{{ range $platform := splitList " " $platforms }}
+{{ $parts := splitList "/" $platform }}
+{{ $os := index $parts 0 }}
+{{ $arch := index $parts 1 }}
   {{ $os }}_{{ $arch }}_checksum_url:
     kind: temurin
     spec:
+      architecture: {{ index $.mappedArch $arch }}
       featureversion: {{ $major }}
+      operatingsystem: {{ index $.mappedOs $os }}
       releasetype: {{ $releasetype }}
       result: checksum_url
-      operatingsystem: {{ $os }}
-      architecture: {{ $arch}}
-
+  {{ $os }}_{{ $arch }}_checksum_value:
+    dependson:
+      - {{ $os }}_{{ $arch }}_checksum_url
+    kind: file
+    spec:
+      {{ $filesource := print $os "_" $arch "_checksum_url" }}
+      file: '{{ source $filesource }}'
+    transformers:
+      - findsubmatch:
+          pattern: "^([a-f0-9]+)"
+  {{ $os }}_{{ $arch }}_installer_url:
+    kind: temurin
+    spec:
+      architecture: {{ index $.mappedArch $arch }}
+      featureversion: {{ $major }}
+      operatingsystem: {{ index $.mappedOs $os }}
+      releasetype: {{ $releasetype }}
+      result: installer_url
+  {{ $os }}_{{ $arch }}_signature_url:
+    kind: temurin
+    spec:
+      architecture: {{ index $.mappedArch $arch }}
+      featureversion: {{ $major }}
+      operatingsystem: {{ index $.mappedOs $os }}
+      releasetype: {{ $releasetype }}
+      result: signature_url
 {{ end }}
 
 conditions:
-  checkIfReleaseIsAvailableForall:
+{{ range $platform := splitList " " $platforms }}
+{{ $parts := splitList "/" $platform }}
+{{ $os := index $parts 0 }}
+{{ $arch := index $parts 1 }}
+
+  syn_checkIfReleaseIsAvailableFor{{ $platform }}:
     kind: temurin
     # checked version comes from the source
     sourceid: lastReleaseVersion
     spec:
       # release type is mandatory to support ea version (bug in updatecli)
       releasetype: {{ $releasetype }}
-      ## todo try to change by { { .platforms  } }
       platforms:
-{{ range $platform := $.platforms }}
-{{ $arch := $platform.arch}}
-{{ $os := $platform.os }}
-        - {{ $os }}/{{ $arch }}
+        - {{ index $.mappedOs $os }}/{{ index $.mappedArch $arch }}
 {{ end }}
 
 targets:
@@ -83,6 +95,7 @@ targets:
     sourceid: lastReleaseVersion
     name: Update the JDK{{ $major }} version in the goss test
     kind: yaml
+    # scmid: default
 {{ if (eq $major 8) }}
     transformers:
       - findsubmatch:
@@ -96,42 +109,61 @@ targets:
         - tests/goss-linux.yaml
         - tests/goss-windows.yaml
       key: $.command.jdk{{ $major }}.{{ if (ne $major 8) }}stdout{{ else }}stderr{{ end }}[0]
-    # scmid: default
-{{ range $platform := $.platforms }}
-{{ $arch := $platform.arch}}
-{{ $os := $platform.os }}
-  {{ $os }}_{{ $arch }}_updatelocals_installer_url:
-    name: Update locals installer_url for JDK{{ $major }} version in jdks_infos.yaml for {{ $platform }}
-    sourceid: {{ $os }}_{{ $arch }}_installer_url
+{{ range $platform := splitList " " $platforms }}
+{{ $parts := splitList "/" $platform }}
+{{ $os := index $parts 0 }}
+{{ $arch := index $parts 1 }}
+{{ $field := "installer_url"}}
+  update_{{ $field }}_{{ $platform }}:
+    name: update {{ $field }} in jdks_infos.yaml for {{ $platform }}
+    sourceid: {{ $os }}_{{ $arch }}_{{ $field }}
     kind: yaml
+    # scmid: default
     spec:
       file: ./jdks_infos.yaml
-      key: $.{{ $os }}.{{ index $.mappedArch $arch }}.jdk{{ $major }}.installer_url
-    # scmid: default
+      key: $.{{ $os }}.{{ $arch }}.jdk{{ $major }}.{{ $field }}
 {{ end }}
-{{ range $platform := $.platforms }}
-{{ $arch := $platform.arch}}
-{{ $os := $platform.os }}
-  {{ $os }}_{{ $arch }}_updatelocals_release_name:
-    name: Update locals release_name for JDK{{ $major }} version in jdks_infos.yaml for {{ $platform }}
-    sourceid: {{ $os }}_{{ $arch }}_release_name
+{{ range $platform := splitList " " $platforms }}
+{{ $parts := splitList "/" $platform }}
+{{ $os := index $parts 0 }}
+{{ $arch := index $parts 1 }}
+{{ $field := "checksum_url"}}
+  update_{{ $field }}_{{ $platform }}:
+    name: update {{ $field }} in jdks_infos.yaml for {{ $platform }}
+    sourceid: {{ $os }}_{{ $arch }}_{{ $field }}
     kind: yaml
+    # scmid: default
     spec:
       file: ./jdks_infos.yaml
-      key: $.{{ $os }}.{{ index $.mappedArch $arch }}.jdk{{ $major }}.release_name
-    # scmid: default
+      key: $.{{ $os }}.{{ $arch }}.jdk{{ $major }}.{{ $field }}
 {{ end }}
-{{ range $platform := $.platforms }}
-{{ $arch := $platform.arch}}
-{{ $os := $platform.os }}
-  {{ $os }}_{{ $arch }}_updatelocals_checksum_url:
-    name: Update locals checksum_url for JDK{{ $major }} version in jdks_infos.yaml for {{ $platform }}
-    sourceid: {{ $os }}_{{ $arch }}_checksum_url
+{{ range $platform := splitList " " $platforms }}
+{{ $parts := splitList "/" $platform }}
+{{ $os := index $parts 0 }}
+{{ $arch := index $parts 1 }}
+{{ $field := "checksum_value"}}
+  update_{{ $field }}_{{ $platform }}:
+    name: update {{ $field }} in jdks_infos.yaml for {{ $platform }}
+    sourceid: {{ $os }}_{{ $arch }}_{{ $field }}
     kind: yaml
+    # scmid: default
     spec:
       file: ./jdks_infos.yaml
-      key: $.{{ $os }}.{{ index $.mappedArch $arch }}.jdk{{ $major }}.checksum_url
+      key: $.{{ $os }}.{{ $arch }}.jdk{{ $major }}.{{ $field }}
+{{ end }}
+{{ range $platform := splitList " " $platforms }}
+{{ $parts := splitList "/" $platform }}
+{{ $os := index $parts 0 }}
+{{ $arch := index $parts 1 }}
+{{ $field := "release_name"}}
+  update_{{ $field }}_{{ $platform }}:
+    name: update {{ $field }} in jdks_infos.yaml for {{ $platform }}
+    sourceid: lastReleaseVersion
+    kind: yaml
     # scmid: default
+    spec:
+      file: ./jdks_infos.yaml
+      key: $.{{ $os }}.{{ $arch }}.jdk{{ $major }}.{{ $field }}
 {{ end }}
 
 actions:

--- a/updatecli/updatecli.d/jdks.yml
+++ b/updatecli/updatecli.d/jdks.yml
@@ -24,6 +24,34 @@ sources:
       releasetype: {{ $releasetype }}
     transformers:
       - trimprefix: "jdk{{ if (ne $major 8) }}-{{ end }}"
+{{ range $platform := $.platforms }}
+{{ $arch := $platform.arch}}
+{{ $os := $platform.os }}
+  {{ $os }}_{{ $arch }}_release_name:
+    kind: temurin
+    spec:
+      featureversion: {{ $major }}
+      releasetype: {{ $releasetype }}
+      result: version
+      operatingsystem: {{ $os }}
+      architecture: {{ $arch}}
+  {{ $os }}_{{ $arch }}_installer_url:
+    kind: temurin
+    spec:
+      featureversion: {{ $major }}
+      releasetype: {{ $releasetype }}
+      result: installer_url
+      operatingsystem: {{ $os }}
+      architecture: {{ $arch}}
+  {{ $os }}_{{ $arch }}_checksum_url:
+    kind: temurin
+    spec:
+      featureversion: {{ $major }}
+      releasetype: {{ $releasetype }}
+      result: checksum_url
+      operatingsystem: {{ $os }}
+      architecture: {{ $arch}}
+{{ end }}
 
 conditions:
   checkIfReleaseIsAvailableForall:
@@ -33,20 +61,25 @@ conditions:
     spec:
       # release type is mandatory to support ea version (bug in updatecli)
       releasetype: {{ $releasetype }}
+      ## todo try to change by { { .platforms  } }
       platforms:
-        - linux/x64
-        - linux/aarch64
-        - windows/x64
+{{ range $platform := $.platforms }}
+{{ $arch := $platform.arch}}
+{{ $os := $platform.os }}
+        - {{ $os }}/{{ $arch }}
+{{ end }}
 
 targets:
   updateJDKVersion:
+    sourceid: lastReleaseVersion
     name: Update the JDK{{ $major }} version in the Packer default values
     kind: yaml
     spec:
       file: "provisioning/tools-versions.yml"
       key: "$.jdk{{ $major }}_version"
-    scmid: default
+    # scmid: default
   updateJDKVersionInGoss:
+    sourceid: lastReleaseVersion
     name: Update the JDK{{ $major }} version in the goss test
     kind: yaml
 {{ if (eq $major 8) }}
@@ -62,7 +95,43 @@ targets:
         - tests/goss-linux.yaml
         - tests/goss-windows.yaml
       key: $.command.jdk{{ $major }}.{{ if (ne $major 8) }}stdout{{ else }}stderr{{ end }}[0]
-    scmid: default
+    # scmid: default
+{{ range $platform := $.platforms }}
+{{ $arch := $platform.arch}}
+{{ $os := $platform.os }}
+  {{ $os }}_{{ $arch }}_updatelocals_installer_url:
+    name: Update locals installer_url for JDK{{ $major }} version in locals.pkr.hcl for {{ $platform }}
+    sourceid: {{ $os }}_{{ $arch }}_installer_url
+    kind: yaml
+    spec:
+      file: ./jdks_infos.yaml
+      key: $.{{ $os }}.{{ $arch }}.jdk{{ $major }}.installer_url
+    # scmid: default
+{{ end }}
+{{ range $platform := $.platforms }}
+{{ $arch := $platform.arch}}
+{{ $os := $platform.os }}
+  {{ $os }}_{{ $arch }}_updatelocals_release_name:
+    name: Update locals release_name for JDK{{ $major }} version in locals.pkr.hcl for {{ $platform }}
+    sourceid: {{ $os }}_{{ $arch }}_release_name
+    kind: yaml
+    spec:
+      file: ./jdks_infos.yaml
+      key: $.{{ $os }}.{{ $arch }}.jdk{{ $major }}.release_name
+    # scmid: default
+{{ end }}
+{{ range $platform := $.platforms }}
+{{ $arch := $platform.arch}}
+{{ $os := $platform.os }}
+  {{ $os }}_{{ $arch }}_updatelocals_checksum_url:
+    name: Update locals checksum_url for JDK{{ $major }} version in locals.pkr.hcl for {{ $platform }}
+    sourceid: {{ $os }}_{{ $arch }}_checksum_url
+    kind: yaml
+    spec:
+      file: ./jdks_infos.yaml
+      key: $.{{ $os }}.{{ $arch }}.jdk{{ $major }}.checksum_url
+    # scmid: default
+{{ end }}
 
 actions:
   default:

--- a/updatecli/updatecli.d/jdks.yml
+++ b/updatecli/updatecli.d/jdks.yml
@@ -51,6 +51,7 @@ sources:
       result: checksum_url
       operatingsystem: {{ $os }}
       architecture: {{ $arch}}
+
 {{ end }}
 
 conditions:
@@ -100,36 +101,36 @@ targets:
 {{ $arch := $platform.arch}}
 {{ $os := $platform.os }}
   {{ $os }}_{{ $arch }}_updatelocals_installer_url:
-    name: Update locals installer_url for JDK{{ $major }} version in locals.pkr.hcl for {{ $platform }}
+    name: Update locals installer_url for JDK{{ $major }} version in jdks_infos.yaml for {{ $platform }}
     sourceid: {{ $os }}_{{ $arch }}_installer_url
     kind: yaml
     spec:
       file: ./jdks_infos.yaml
-      key: $.{{ $os }}.{{ $arch }}.jdk{{ $major }}.installer_url
+      key: $.{{ $os }}.{{ index $.mappedArch $arch }}.jdk{{ $major }}.installer_url
     # scmid: default
 {{ end }}
 {{ range $platform := $.platforms }}
 {{ $arch := $platform.arch}}
 {{ $os := $platform.os }}
   {{ $os }}_{{ $arch }}_updatelocals_release_name:
-    name: Update locals release_name for JDK{{ $major }} version in locals.pkr.hcl for {{ $platform }}
+    name: Update locals release_name for JDK{{ $major }} version in jdks_infos.yaml for {{ $platform }}
     sourceid: {{ $os }}_{{ $arch }}_release_name
     kind: yaml
     spec:
       file: ./jdks_infos.yaml
-      key: $.{{ $os }}.{{ $arch }}.jdk{{ $major }}.release_name
+      key: $.{{ $os }}.{{ index $.mappedArch $arch }}.jdk{{ $major }}.release_name
     # scmid: default
 {{ end }}
 {{ range $platform := $.platforms }}
 {{ $arch := $platform.arch}}
 {{ $os := $platform.os }}
   {{ $os }}_{{ $arch }}_updatelocals_checksum_url:
-    name: Update locals checksum_url for JDK{{ $major }} version in locals.pkr.hcl for {{ $platform }}
+    name: Update locals checksum_url for JDK{{ $major }} version in jdks_infos.yaml for {{ $platform }}
     sourceid: {{ $os }}_{{ $arch }}_checksum_url
     kind: yaml
     spec:
       file: ./jdks_infos.yaml
-      key: $.{{ $os }}.{{ $arch }}.jdk{{ $major }}.checksum_url
+      key: $.{{ $os }}.{{ index $.mappedArch $arch }}.jdk{{ $major }}.checksum_url
     # scmid: default
 {{ end }}
 

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -11,3 +11,10 @@ jdks:
   - major: 11
   - major: 17
   - major: 21
+platforms:
+  - os: linux
+    arch: x64
+  - os: linux
+    arch: aarch64
+  - os: windows
+    arch: x64

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -7,20 +7,13 @@ github:
   repository: "packer-images"
 
 jdks:
-  # - major: 8
+  - major: 8
   - major: 11
-  # - major: 17
-  # - major: 21
-platforms:
-  # - os: linux
-  #   arch: x64
-  - os: linux
-    arch: aarch64
-  # - os: windows
-  #   arch: x64
+  - major: 17
+  - major: 21
 mappedArch:
-  x64: amd64
-  aarch64: arm64
+  amd64: x64
+  arm64: aarch64
 mappedOs:
-  linux: ubuntu
+  ubuntu: linux
   windows: windows

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -7,14 +7,20 @@ github:
   repository: "packer-images"
 
 jdks:
-  - major: 8
+  # - major: 8
   - major: 11
-  - major: 17
-  - major: 21
+  # - major: 17
+  # - major: 21
 platforms:
-  - os: linux
-    arch: x64
+  # - os: linux
+  #   arch: x64
   - os: linux
     arch: aarch64
-  - os: windows
-    arch: x64
+  # - os: windows
+  #   arch: x64
+mappedArch:
+  x64: amd64
+  aarch64: arm64
+mappedOs:
+  linux: ubuntu
+  windows: windows


### PR DESCRIPTION
WIP	

updatecli to keep jdks yaml file uptodate, work with https://github.com/jenkins-infra/packer-images/pull/1952