### PR TITLE
chore(updatecli) fix maven manifest (missing Windows target)

### DIFF
--- a/updatecli/updatecli.d/maven.yml
+++ b/updatecli/updatecli.d/maven.yml
@@ -44,6 +44,7 @@ targets:
     spec:
       files:
         - tests/goss-linux.yaml
+        - tests/goss-windows.yaml
       key: $.command.maven.stdout[0]
     scmid: default
 


### PR DESCRIPTION
Not sure why https://github.com/jenkins-infra/packer-images/pull/1989 did not fail on Windows. 

But #1989 did not update the Windows tests so here is the fix.

