### PR TITLE
feat: add JDK25 version `25+26-EA`

### DIFF
--- a/jdks-infos.yaml
+++ b/jdks-infos.yaml
@@ -13,6 +13,9 @@ ubuntu:
     jdk21:
       installer_url: https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.7%2B6/OpenJDK21U-jdk_x64_linux_hotspot_21.0.7_6.tar.gz
       checksum_value: 974d3acef0b7193f541acb61b76e81670890551366625d4f6ca01b91ac152ce0
+    jdk25:
+      installer_url: https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B26-ea-beta/OpenJDK-jdk_x64_linux_hotspot_25_26-ea.tar.gz
+      checksum_value: 09c1d4e0d07ac7972db467de49d2e6eae215e3060aee97381d844239474b83e9
   arm64:
     jdk8:
       installer_url: https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u452-b09/OpenJDK8U-jdk_aarch64_linux_hotspot_8u452b09.tar.gz
@@ -26,6 +29,9 @@ ubuntu:
     jdk21:
       installer_url: https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.7%2B6/OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.7_6.tar.gz
       checksum_value: 31dba70ba928c78c20d62049ac000f79f7a7ab11f9d9c11e703f52d60aa64f93
+    jdk25:
+      installer_url: https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B26-ea-beta/OpenJDK-jdk_aarch64_linux_hotspot_25_26-ea.tar.gz
+      checksum_value: 9a18eddcbcc2f94e81b8ff197284fc3bdb3825bf893c2eda2b77667e1ee1ef7f
 windows:
   amd64:
     jdk8:
@@ -40,3 +46,6 @@ windows:
     jdk21:
       installer_url: https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.7%2B6/OpenJDK21U-jdk_x64_windows_hotspot_21.0.7_6.zip
       checksum_value: 38f4b9fa0b36def9812f6576fd45f6224630477db8c4e669ee78eaa35abb9195
+    jdk25:
+      installer_url: https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B25-ea-beta/OpenJDK-jdk_x64_windows_hotspot_25_25-ea.zip
+      checksum_value: 8070571fbe2941a4b5ae068635d0f20a3b8b99d73a3f2d014f2748da85655d8e

--- a/jdks-infos.yaml
+++ b/jdks-infos.yaml
@@ -14,7 +14,9 @@ ubuntu:
       installer_url: https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.7%2B6/OpenJDK21U-jdk_x64_linux_hotspot_21.0.7_6.tar.gz
       checksum_value: 974d3acef0b7193f541acb61b76e81670890551366625d4f6ca01b91ac152ce0
     jdk25:
+      #TODO track with updatecli
       installer_url: https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B26-ea-beta/OpenJDK-jdk_x64_linux_hotspot_25_26-ea.tar.gz
+      #TODO track with updatecli
       checksum_value: 09c1d4e0d07ac7972db467de49d2e6eae215e3060aee97381d844239474b83e9
   arm64:
     jdk8:
@@ -30,7 +32,9 @@ ubuntu:
       installer_url: https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.7%2B6/OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.7_6.tar.gz
       checksum_value: 31dba70ba928c78c20d62049ac000f79f7a7ab11f9d9c11e703f52d60aa64f93
     jdk25:
+      #TODO track with updatecli
       installer_url: https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B26-ea-beta/OpenJDK-jdk_aarch64_linux_hotspot_25_26-ea.tar.gz
+      #TODO track with updatecli
       checksum_value: 9a18eddcbcc2f94e81b8ff197284fc3bdb3825bf893c2eda2b77667e1ee1ef7f
 windows:
   amd64:
@@ -47,5 +51,7 @@ windows:
       installer_url: https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.7%2B6/OpenJDK21U-jdk_x64_windows_hotspot_21.0.7_6.zip
       checksum_value: 38f4b9fa0b36def9812f6576fd45f6224630477db8c4e669ee78eaa35abb9195
     jdk25:
+      #TODO track with updatecli
       installer_url: https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B25-ea-beta/OpenJDK-jdk_x64_windows_hotspot_25_25-ea.zip
+      #TODO track with updatecli
       checksum_value: 8070571fbe2941a4b5ae068635d0f20a3b8b99d73a3f2d014f2748da85655d8e

--- a/tests/goss-linux.yaml
+++ b/tests/goss-linux.yaml
@@ -73,7 +73,7 @@ command:
     exec: /opt/jdk-25/bin/java --version
     exit-status: 0
     stdout:
-      - 25+26-ea-beta
+      - 25-26+ea-beta
   jdk8:
     exec: /opt/jdk-8/bin/java -version
     exit-status: 0

--- a/tests/goss-linux.yaml
+++ b/tests/goss-linux.yaml
@@ -69,6 +69,11 @@ command:
     exit-status: 0
     stdout:
       - 21.0.7+6
+  jdk25:
+    exec: /opt/jdk-25/bin/java --version
+    exit-status: 0
+    stdout:
+      - 25+26-ea-beta
   jdk8:
     exec: /opt/jdk-8/bin/java -version
     exit-status: 0

--- a/tests/goss-linux.yaml
+++ b/tests/goss-linux.yaml
@@ -73,7 +73,7 @@ command:
     exec: /opt/jdk-25/bin/java --version
     exit-status: 0
     stdout:
-      - 25-26+ea-beta
+      - 25-beta+26-ea
   jdk8:
     exec: /opt/jdk-8/bin/java -version
     exit-status: 0

--- a/tests/goss-windows.yaml
+++ b/tests/goss-windows.yaml
@@ -29,7 +29,7 @@ command:
     exec: C:\tools\jdk-25\bin\java --version
     exit-status: 0
     stdout:
-      - 25+26-ea-beta
+      - 25-beta+26-ea
   jdk8:
     exec: C:\tools\jdk-8\bin\java -version
     exit-status: 0

--- a/tests/goss-windows.yaml
+++ b/tests/goss-windows.yaml
@@ -25,6 +25,11 @@ command:
     exit-status: 0
     stdout:
       - 21.0.7+6
+  jdk25:
+    exec: C:\tools\jdk-25\bin\java --version
+    exit-status: 0
+    stdout:
+      - 25+26-ea-beta
   jdk8:
     exec: C:\tools\jdk-8\bin\java -version
     exit-status: 0

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -7,7 +7,9 @@ github:
   repository: "packer-images"
 
 jdks:
-  - major: 8
-  - major: 11
-  - major: 17
-  - major: 21
+  # - major: 8
+  # - major: 11
+  # - major: 17
+  # - major: 21
+  - major: 25
+    releasetype: ea

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -11,5 +11,3 @@ jdks:
   - major: 11
   - major: 17
   - major: 21
-  - major: 25
-    releasetype: ea

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -7,9 +7,9 @@ github:
   repository: "packer-images"
 
 jdks:
-  # - major: 8
-  # - major: 11
-  # - major: 17
-  # - major: 21
+  - major: 8
+  - major: 11
+  - major: 17
+  - major: 21
   - major: 25
     releasetype: ea


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4641

introducing jdk25 in agents templates