### PR TITLE
chore(updatecli): track the jdk25 version

### DIFF
--- a/tests/goss-linux.yaml
+++ b/tests/goss-linux.yaml
@@ -73,7 +73,7 @@ command:
     exec: /opt/jdk-25/bin/java --version
     exit-status: 0
     stdout:
-      - 25-beta+26-ea
+      - "25+26"
   jdk8:
     exec: /opt/jdk-8/bin/java -version
     exit-status: 0

--- a/tests/goss-windows.yaml
+++ b/tests/goss-windows.yaml
@@ -29,7 +29,7 @@ command:
     exec: C:\tools\jdk-25\bin\java --version
     exit-status: 0
     stdout:
-      - 25-beta+26-ea
+      - 25+26
   jdk8:
     exec: C:\tools\jdk-8\bin\java -version
     exit-status: 0

--- a/tests/goss-windows.yaml
+++ b/tests/goss-windows.yaml
@@ -29,7 +29,7 @@ command:
     exec: C:\tools\jdk-25\bin\java --version
     exit-status: 0
     stdout:
-      - 25+26
+      - "25+26"
   jdk8:
     exec: C:\tools\jdk-8\bin\java -version
     exit-status: 0

--- a/updatecli/updatecli.d/jdks.yml
+++ b/updatecli/updatecli.d/jdks.yml
@@ -62,7 +62,7 @@ targets:
     sourceid: lastReleaseVersion
     name: Update the JDK{{ $major }} version in the goss test
     kind: yaml
-    scmid: default
+    # scmid: default
 {{ if (eq $major 8) }}
     transformers:
       - findsubmatch:

--- a/updatecli/updatecli.d/jdks.yml
+++ b/updatecli/updatecli.d/jdks.yml
@@ -25,6 +25,9 @@ sources:
       releasetype: {{ $releasetype }}
     transformers:
       - trimprefix: "jdk{{ if (ne $major 8) }}-{{ end }}"
+{{ if (eq $releasetype "ea") }}
+      - trimsuffix: "-ea-beta"
+{{ end }}
 {{ range $platform := splitList " " $platforms }}
 {{ $parts := splitList "/" $platform }}
 {{ $os := index $parts 0 }}
@@ -62,7 +65,7 @@ targets:
     sourceid: lastReleaseVersion
     name: Update the JDK{{ $major }} version in the goss test
     kind: yaml
-    # scmid: default
+    scmid: default
 {{ if (eq $major 8) }}
     transformers:
       - findsubmatch:

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -7,9 +7,9 @@ github:
   repository: "packer-images"
 
 jdks:
-  - major: 8
-  - major: 11
-  - major: 17
-  - major: 21
+  # - major: 8
+  # - major: 11
+  # - major: 17
+  # - major: 21
   - major: 25
     releasetype: ea

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -11,3 +11,5 @@ jdks:
   - major: 11
   - major: 17
   - major: 21
+  - major: 25
+    releasetype: ea

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -7,9 +7,9 @@ github:
   repository: "packer-images"
 
 jdks:
-  # - major: 8
-  # - major: 11
-  # - major: 17
-  # - major: 21
+  - major: 8
+  - major: 11
+  - major: 17
+  - major: 21
   - major: 25
     releasetype: ea


### PR DESCRIPTION
as per https://github.com/jenkins-infra/packer-images/pull/1998#discussion_r2139639182
moving the updatecli manifest change to this PR

⚠️ need https://github.com/jenkins-infra/packer-images/pull/1998 to be merged and then rebase this one before merging
