### PR TITLE
chore(updatecli): add dependson target to avoid changing goss test if not all target have been applied

### DIFF
--- a/updatecli/updatecli.d/jdks.yml
+++ b/updatecli/updatecli.d/jdks.yml
@@ -66,6 +66,11 @@ targets:
     name: Update the JDK{{ $major }} version in the goss test
     kind: yaml
     scmid: default
+    dependson:
+{{ range $platform := splitList " " $platforms }}
+      - target#update_installer_url_{{ $platform }}:AND
+      - target#update_checksum_value_{{ $platform }}:AND
+{{ end }}
 {{ if (eq $major 8) }}
     transformers:
       - findsubmatch:


### PR DESCRIPTION
following the error from the temurin api call: https://github.com/adoptium/api.adoptium.net/issues/1523

avoiding target change on goss if one of the platform is not updated