### PR TITLE
chore(updatecli): temporarily remove jdk25 tracking

### DIFF
--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -11,5 +11,5 @@ jdks:
   - major: 11
   - major: 17
   - major: 21
-  - major: 25
-    releasetype: ea
+  # - major: 25
+  #   releasetype: ea


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4707

wait for #2012 to check if the dependon work as expected