### PR TITLE
Revert "chore(updatecli): temporarily remove jdk25 tracking"

### DIFF
--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -11,5 +11,5 @@ jdks:
   - major: 11
   - major: 17
   - major: 21
-  # - major: 25
-  #   releasetype: ea
+  - major: 25
+    releasetype: ea


### PR DESCRIPTION
Reverts jenkins-infra/packer-images#2013

following https://github.com/adoptium/api.adoptium.net/issues/1523#issuecomment-2983064226