### PR TITLE
fix(linux/windows) Ensure Maven archive is always downloaded when a new version is available while we use an older one

### DIFF
--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -370,8 +370,11 @@ function install_sops(){
 
 ## Ensure that maven is installed and configured (version from environment)
 function install_maven() {
+  # If the Apache mirrors responds an error, we usually fallback to their "archives" system as it hosts older Maven versions
   curl --fail --silent --location --show-error --output "/tmp/apache-maven-${MAVEN_VERSION}-bin.tar.gz" \
-    "https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz"
+    "https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" \
+  || curl --fail --silent --location --show-error --output "/tmp/apache-maven-${MAVEN_VERSION}-bin.tar.gz" \
+    "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz"
 
   tar --extract --gunzip --file="/tmp/apache-maven-${MAVEN_VERSION}-bin.tar.gz" --directory=/usr/share/
   ln -s "/usr/share/apache-maven-${MAVEN_VERSION}/bin/mvn" /usr/bin/mvn

--- a/provisioning/windows-provision.ps1
+++ b/provisioning/windows-provision.ps1
@@ -148,7 +148,8 @@ foreach ($jdkMajorVersion in $jdkList) {
 }
 
 $downloads['maven'] = @{
-    'url' = 'https://dlcdn.apache.org/maven/maven-3/{0}/binaries/apache-maven-{0}-bin.zip' -f $env:MAVEN_VERSION;
+    # We should use the 'archives' downoad system to ensure we always find older version (as the mirror download system only provide latest)
+    'url' = 'https://archive.apache.org/dist/maven/maven-3/{0}/binaries/apache-maven-{0}-bin.zip'  -f $env:MAVEN_VERSION;
     'local' = "$baseDir\maven.zip";
     'expandTo' = $baseDir;
     'path' = '{0}\apache-maven-{1}\bin' -f $baseDir,$env:MAVEN_VERSION;


### PR DESCRIPTION
Note: I did a "fallback" technique on Linux (try normal download otherwise fallback to archives) and tested it locally.

For Windows I've been lazy and provided a quick fix: always use the archives system.