### PR TITLE
chore(updatecli/kubectl) bump line from `1.31.x` to `1.32.x`

### DIFF
--- a/updatecli/updatecli.d/kubectl.yaml
+++ b/updatecli/updatecli.d/kubectl.yaml
@@ -26,7 +26,7 @@ sources:
       username: "{{ .github.username }}"
       versionfilter:
         kind: regex
-        pattern: "^kubernetes-1.31.(\\d*)$"
+        pattern: "^kubernetes-1.32.(\\d*)$"
 
 targets:
   updateVersion:


### PR DESCRIPTION
We're going to upgrade Kubernetes to 1.32 and a new `publick8s` cluster is gonna be created directly in 1.32.

As such, let's move the Kubernetes client to 1.32. It will keep compatibility with 1.31.x servers.