### PR TITLE
chore(updatecli) track JDK25 `GA` instead `EA`

### DIFF
--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -12,4 +12,3 @@ jdks:
   - major: 17
   - major: 21
   - major: 25
-    releasetype: ea


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4831