### PR TITLE
chore: update `kubectl` to 1.33.5 and update its manifest release line from 1.32 to 1.33

### DIFF
--- a/provisioning/tools-versions.yml
+++ b/provisioning/tools-versions.yml
@@ -25,7 +25,7 @@ helm_secrets_version: 4.6.11
 jenkins_remoting_version: 3345.v03dee9b_f88fc
 jq_version: 1.6
 jxreleaseversion_version: 2.7.10
-kubectl_version: 1.32.9
+kubectl_version: 1.33.5
 launchable_version: 1.66.0
 maven_version: 3.9.11
 netlifydeploy_version: 0.1.8

--- a/updatecli/updatecli.d/kubectl.yaml
+++ b/updatecli/updatecli.d/kubectl.yaml
@@ -26,7 +26,7 @@ sources:
       username: "{{ .github.username }}"
       versionfilter:
         kind: regex
-        pattern: "^kubernetes-1.32.(\\d*)$"
+        pattern: "^kubernetes-1.33.(\\d*)$"
 
 targets:
   updateVersion:


### PR DESCRIPTION
This PR update `kubectl` to 1.33.5, and update its updatecli manifest to the 1.33 release line.

Testing done:
```
$ updatecli diff --config ./updatecli/updatecli.d/kubectl.yaml --values updatecli/values.yaml
##########################
# BUMP `KUBECTL` VERSION #
##########################

source: source#lastReleaseVersion
-------------------------
WARNING: ⚠ No GitHub Release found, we fallback to published git tags
Searching for version matching pattern "^kubernetes-1.33.(\\d*)$"
✔ GitHub release version "kubernetes-1.33.5" found matching pattern "^kubernetes-1.33.(\\d*)$" of kind "regex"
[transformers]
✔ Result correctly transformed from "kubernetes-1.33.5" to "1.33.5"

target: target#updateVersionInGoss
--------------------------

**Dry Run enabled**

⚠ - change detected:
        * key "$.command.kubectl.stdout[0]" should be updated from "1.32.9" to "1.33.5", in file "tests/goss-common.yaml"


CHANGELOG:
----------

target: target#updateVersion
--------------------

**Dry Run enabled**

⚠ - change detected:
        * key "$.kubectl_version" should be updated from "1.32.9" to "1.33.5", in file "provisioning/tools-versions.yml"


CHANGELOG:
----------


ACTIONS
========


Bump `kubectl` version
  => Bump `kubectl` version to 1.33.5

[Dry Run] An action of kind "github/pullrequest" is expected.

=============================

SUMMARY:



⚠ Bump `kubectl` version:
        Source:
                ✔ [lastReleaseVersion] Get latest `kubectl` CLI version
        Target:
                ⚠ [updateVersion] Update `kubectl` version in the tools-versions.yml file
                ⚠ [updateVersionInGoss] Update `kubectl` version in the goss test


Run Summary
===========
Pipeline(s) run:
  * Changed:    1
  * Failed:     0
  * Skipped:    0
  * Succeeded:  0
  * Total:      1
```

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4820