### PR TITLE
chore(updatecli): update `kubectl` release line to 1.33

### DIFF
--- a/updatecli/updatecli.d/kubectl.yaml
+++ b/updatecli/updatecli.d/kubectl.yaml
@@ -26,7 +26,7 @@ sources:
       username: "{{ .github.username }}"
       versionfilter:
         kind: regex
-        pattern: "^kubernetes-1.32.(\\d*)$"
+        pattern: "^kubernetes-1.33.(\\d*)$"
 
 targets:
   updateVersion:


### PR DESCRIPTION
Ref: 
- https://github.com/jenkins-infra/helpdesk/issues/4820#issuecomment-3481014093

This PR updates the release line of `kubectl` to `1.33`

Tested locally with success:

```
CHANGELOG:
----------

target: target#updateVersionInGoss
--------------------------

**Dry Run enabled**

⚠ - change detected:
        * key "$.command.kubectl.stdout[0]" should be updated from "1.32.9" to "1.33.5", in file "tests/goss-common.yaml"

```

We will use Kubernetes `v.1.33.5` for the upgrade