### PR TITLE
chore(updatecli/azure-windows): don't hardcode `2019` in the source SKU

### DIFF
--- a/updatecli/updatecli.d/azure-windows.yml
+++ b/updatecli/updatecli.d/azure-windows.yml
@@ -23,7 +23,7 @@ sources:
     spec:
       command: >-
         az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID > /dev/null \
-          && az vm image list --location eastus --publisher MicrosoftWindowsServer --offer WindowsServer --sku 2019-datacenter-core-g2 --all \
+          && az vm image list --location eastus --publisher MicrosoftWindowsServer --offer WindowsServer --sku {{ $version }}-datacenter-core-g2 --all \
           --query "[?offer=='WindowsServer'].version" -o tsv | sort -u | tail -n 1
       environments:
         - name: PATH


### PR DESCRIPTION
This change actually use `$version` in 1cadd77852bb9b68e5c1860d4de0a47e59132a44 when querying available SKU Windows versions with `az vm image list`.

Fixup of:
- #2441
