### PR TITLE
feat(Jenkinsfile_k8s): publish build status report on release tag builds

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -177,6 +177,9 @@ node('linux-arm64-docker') {
             }
           }
         }
+        stage('Publish Build Status Report') {
+          publishBuildStatusReport()
+        }
       }
     }
   }


### PR DESCRIPTION
Ref:
- https://github.com/jenkins-infra/helpdesk/issues/2843

Adds a `publishBuildStatusReport()` stage after the Docker manifest build on release tag builds, enabling staleness monitoring for this job.

Gated by `env.TAG_NAME` so only release builds publish status reports.
