### PR TITLE
chore(updatecli): Track nodejs `v24.x` version (instead of `22.x`)

### DIFF
--- a/updatecli/updatecli.d/nodejs-linux.yml
+++ b/updatecli/updatecli.d/nodejs-linux.yml
@@ -24,7 +24,7 @@ sources:
       username: "{{ .github.username }}"
       versionfilter:
         kind: regex
-        pattern: v22.(\d*).(\d*)
+        pattern: v24.(\d*).(\d*)
     transformers:
       - trimprefix: v
 

--- a/updatecli/updatecli.d/nodejs-windows.yml
+++ b/updatecli/updatecli.d/nodejs-windows.yml
@@ -24,7 +24,7 @@ sources:
       username: "{{ .github.username }}"
       versionfilter:
         kind: regex
-        pattern: v22.(\d*).(\d*)
+        pattern: v24.(\d*).(\d*)
     transformers:
       - trimprefix: v
 


### PR DESCRIPTION
Ref:

- https://github.com/jenkins-infra/helpdesk/issues/5080

This PR tracks the latest versions for `nodejs` v24.xx (Linux & Windows)

Tested locally with success 

```
ACTIONS
========


Bump Node.js version on Windows
  => Bump Node.js version on Windows to 24.15.0

[Dry Run] An action of kind "github/pullrequest" is expected.

ACTIONS
========


Bump Node.js version on Linux
  => Bump Node.js version on Linux to 24.15.0

[Dry Run] An action of kind "github/pullrequest" is expected.