### PR TITLE
chore(updatecli) use a shell script (instead of inline command) to fetch latest nuget version to allow easier debugging

### DIFF
--- a/updatecli/scripts/fetch-nuget-latest-version.sh
+++ b/updatecli/scripts/fetch-nuget-latest-version.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Fail script on instruction failure
+set -e
+# Same (fail script on instruction failure) inside pipelines
+set -o pipefail
+# Helps debugging from updatecli
+set -x
+# Safety net for unset variables
+set -u
+
+nuget_dist_json="$(curl --silent --show-error --location --fail https://dist.nuget.org/index.json)"
+nuget_dist_versions="$(echo "${nuget_dist_json}" | jq -r '.artifacts.[] | select(.name == "win-x86-commandline") | .versions[].version')"
+found_version="$(echo "${nuget_dist_versions}" | sort -hr | head -n 1)"
+test -n "${found_version}"
+echo "${found_version}"

--- a/updatecli/updatecli.d/nuget.yaml
+++ b/updatecli/updatecli.d/nuget.yaml
@@ -18,7 +18,7 @@ sources:
     name: Get latest `nuget` version
     kind: shell
     spec:
-      command: curl --silent --fail https://dist.nuget.org/index.json | jq -r '.artifacts.[] | select(.name == "win-x86-commandline") | .versions[].version' | sort -hr | head -n 1
+      command: bash ./updatecli/scripts/fetch-nuget-latest-version.sh
 
 targets:
   updateVersion:


### PR DESCRIPTION
The automatic PR https://github.com/jenkins-infra/packer-images/pull/2660 shows `updatecli` get an empty string source for the manifest's source for Nuget:

<img width="1889" height="493" alt="Capture d’écran 2026-04-29 à 16 15 31" src="https://github.com/user-attachments/assets/95fb089e-fd5a-488b-8011-32fe11e17c88" />

This PR moves the command into a shell script with:
- Usual shell debugs (not existing on a direct `command` spawned by `updatecli` which usually default to `sh`)
- Split of the different steps to ease analysis (step by step)
- Enable shell debug (to have output in `updatecli` output when script fails)
- Add an explicit shell test (tried locally with success: it fails if the found version is empty) as a safety net
