### PR TITLE
chore(windows) install pwsh with nuget instead of chocolatey

### DIFF
--- a/build-jenkins-agent-windows.pkr.hcl
+++ b/build-jenkins-agent-windows.pkr.hcl
@@ -113,6 +113,13 @@ build {
     disable = true
   }
 
+  # Sanity check for PowerShell: ensure that pwsh is present
+  provisioner "powershell" {
+    inline = [
+      "pwsh --version",
+    ]
+  }
+  
   #provisioner "powershell" {
   #  max_retries      = 2
   #  environment_vars = local.provisioning_env_vars

--- a/provisioning/windows-provision.ps1
+++ b/provisioning/windows-provision.ps1
@@ -394,20 +394,11 @@ foreach($k in $downloads.Keys) {
     }
 }
 
-# Special case for Powershell, we need to make sure powershell.exe and pwsh.exe are both available
-# On Windows Server, Windows Powershell 5.1 is installed by default (powershell.exe)
-# On nanoserver, Powershell Core 7 is installed by default (pwsh.ex)
+# On Windows Server, Windows Powershell 5.x is installed by default (powershell.exe) but we also need Powershell 7.x (pwsh.exe)
 # https://docs.microsoft.com/en-us/powershell/scripting/whats-new/migrating-from-windows-powershell-51-to-powershell-7?view=powershell-7.2#using-powershell-7-side-by-side-with-windows-powershell-51
 Write-Output "== Ensure both Windows Powershell and Powershell Core are available"
-if ((Get-Host | Select-Object Version).Version.Major -eq 5) {
-    Write-Output "= Windows Powershell already present, installing Powershell Core..."
-    Invoke-Command {& "choco.exe" install pwsh --yes --no-progress --limit-output --fail-on-error-output --version "${env:WINDOWS_PWSH_VERSION}";}
-    AddToPathEnv "C:\Program Files\PowerShell\7\"
-} else {
-    Write-Output "= Powershell Core already present, installing Windows Powershell..."
-    Invoke-Command {& "choco.exe" install powershell --yes --no-progress --limit-output --fail-on-error-output;}
-    AddToPathEnv "C:\Windows\System32\WindowsPowerShell\v1.0\"
-}
+"$baseDir\nuget.exe" install powershell -Version "${env:WINDOWS_PWSH_VERSION}";
+AddToPathEnv "C:\Program Files\PowerShell\7\"
 
 ## Enabling LongPaths
 Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem' -Name LongPathsEnabled -type DWord -Value 1

--- a/provisioning/windows-provision.ps1
+++ b/provisioning/windows-provision.ps1
@@ -397,7 +397,7 @@ foreach($k in $downloads.Keys) {
 # On Windows Server, Windows Powershell 5.x is installed by default (powershell.exe) but we also need Powershell 7.x (pwsh.exe)
 # https://docs.microsoft.com/en-us/powershell/scripting/whats-new/migrating-from-windows-powershell-51-to-powershell-7?view=powershell-7.2#using-powershell-7-side-by-side-with-windows-powershell-51
 Write-Output "== Ensure both Windows Powershell and Powershell Core are available"
-& "${baseDir}"\nuget.exe install powershell -Version "${env:WINDOWS_PWSH_VERSION}";
+& "${baseDir}\nuget.exe" install powershell -Version "${env:WINDOWS_PWSH_VERSION}";
 AddToPathEnv "C:\Program Files\PowerShell\7\"
 
 ## Enabling LongPaths

--- a/provisioning/windows-provision.ps1
+++ b/provisioning/windows-provision.ps1
@@ -397,7 +397,7 @@ foreach($k in $downloads.Keys) {
 # On Windows Server, Windows Powershell 5.x is installed by default (powershell.exe) but we also need Powershell 7.x (pwsh.exe)
 # https://docs.microsoft.com/en-us/powershell/scripting/whats-new/migrating-from-windows-powershell-51-to-powershell-7?view=powershell-7.2#using-powershell-7-side-by-side-with-windows-powershell-51
 Write-Output "== Ensure both Windows Powershell and Powershell Core are available"
-"$baseDir\nuget.exe" install powershell -Version "${env:WINDOWS_PWSH_VERSION}";
+& "${baseDir}"\nuget.exe install powershell -Version "${env:WINDOWS_PWSH_VERSION}";
 AddToPathEnv "C:\Program Files\PowerShell\7\"
 
 ## Enabling LongPaths


### PR DESCRIPTION
We keep having, randomly, Windows VM templates without `pwsh`absent:

<img width="1910" height="1042" alt="Capture d’écran 2026-04-30 à 17 48 29" src="https://github.com/user-attachments/assets/4ca311ad-f688-4a78-8495-33526190ef45" />

The logs for these released templates are clear about chocolatey failing to install Powershell Core:

```
[2026-04-29T17:23:59.509Z] [1;32m2026-04-29T17:23:55Z: ==> azure-arm.windows: pwsh package files install completed. Performing other installation steps.[0m
[2026-04-29T17:23:59.510Z] [1;32m2026-04-29T17:23:55Z: ==> azure-arm.windows:  The install of pwsh was successful.[0m
[2026-04-29T17:23:59.510Z] [1;32m2026-04-29T17:23:55Z: ==> azure-arm.windows:   Software install location not explicitly set, it could be in package or[0m
[2026-04-29T17:23:59.510Z] [1;32m2026-04-29T17:23:55Z: ==> azure-arm.windows:   default install location of installer.[0m
[2026-04-29T17:23:59.510Z] [1;32m2026-04-29T17:23:55Z: ==> azure-arm.windows:[0m
[2026-04-29T17:23:59.510Z] [1;32m2026-04-29T17:23:55Z: ==> azure-arm.windows: Chocolatey installed 2/3 packages. 1 packages failed.[0m
[2026-04-29T17:23:59.510Z] [1;32m2026-04-29T17:23:55Z: ==> azure-arm.windows:  See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).[0m
[2026-04-29T17:23:59.510Z] [1;32m2026-04-29T17:23:55Z: ==> azure-arm.windows:[0m
[2026-04-29T17:23:59.510Z] [1;32m2026-04-29T17:23:55Z: ==> azure-arm.windows: Failures[0m
[2026-04-29T17:23:59.510Z] [1;32m2026-04-29T17:23:55Z: ==> azure-arm.windows:  - powershell-core (exited -1) - Error while running 'C:\ProgramData\chocolatey\lib\powershell-core\tools\chocolateyinstall.ps1'.[0m
[2026-04-29T17:23:59.510Z] [1;32m2026-04-29T17:23:55Z: ==> azure-arm.windows:  See log for details.[0m
```


The error is most probably a transient error since it happens randomly on all Windows versions.


This PR tries to fix this by introducing the 2 following changes:
- Install Powershell core using nuget instead of chocolatey (more reliable and Microsoft managed)
- Run a "sanity check" since we [disabled goss tests](#2678) due to instability, to avoid releasing while `pwsh` is absent

