### PR TITLE
fix(windows) ensure Docker Buildx is installed in a valid location

### DIFF
--- a/provisioning/windows-provision.ps1
+++ b/provisioning/windows-provision.ps1
@@ -83,7 +83,7 @@ $baseDir = 'C:\tools'
 New-Item -ItemType Directory -Path $baseDir -Force | Out-Null
 
 # Special case for docker plugins
-$dockerPluginsDir = 'C:\ProgramData\docker\cli-plugins'
+$dockerPluginsDir = "${env:ProgramFiles}"\Docker\cli-plugins
 New-Item -ItemType Directory -Path $dockerPluginsDir -Force | Out-Null
 
 # Ensure NuGet package provider is initialized (non-interactively)


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/5088

Since #2349 which bumped Docker CE from 28.x to 29.x, the system-level plugins installation directiory we were using is deprecated and not checked anymore, leading to the error `docker: unknown command: docker buildx`.

Ref. https://docs.docker.com/engine/release-notes/29/#deprecations-1

> Remove `%PROGRAMDATA%\Docker\cli-plugins` from the list of paths used for CLI plugins on Windows. This path was present for backward compatibility with old installation, but replaced by `%ProgramFiles%\Docker\cli-plugins`. [docker/cli#6713](https://github.com/docker/cli/pull/6713)


This PR changes the installation directory to `${env:ProgramFiles}\Docker\cli-plugins` instead.

----


Tested manually on a pipeline replay on ci.jenkins.io with the agent in version 2.100.1:

```
PS C:\Program Files\Docker\cli-plugins> mkdir "$env:ProgramFiles\Docker\cli-plugins"
PS C:\Program Files\Docker\cli-plugins> cd "$env:ProgramFiles\Docker\cli-plugins"
PS C:\Program Files\Docker\cli-plugins> $ProgressPreference = 'SilentlyContinue' # Disable Progress bar for faster downloads
PS C:\Program Files\Docker\cli-plugins> Invoke-WebRequest "https://github.com/docker/buildx/releases/download/v0.33.0/buildx-v0.33.0.windows-amd64.exe" -Outfile docker-buildx.exe
PS C:\Program Files\Docker\cli-plugins> dir
    Directory: C:\Program Files\Docker\cli-plugins

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a----          5/1/2026   8:24 AM       65599488 docker-buildx.exe

PS C:\Program Files\Docker\cli-plugins> docker buildx info
Usage:  docker buildx [OPTIONS] COMMAND

Extended build capabilities with BuildKit

Options:
      --builder string   Override the configured builder instance
  -D, --debug            Enable debug logging

Management Commands:
  dap         Start debug adapter protocol compatible debugger
  history     Commands to work on build records
  imagetools  Commands to work on images in registry
  policy      Commands for working with build policies

Commands:
  bake        Build from a file
  build       Start a build
  create      Create a new builder instance
  dial-stdio  Proxy current stdio streams to builder instance
  du          Disk usage
  inspect     Inspect current builder instance
  ls          List builder instances
  prune       Remove build cache
  rm          Remove one or more builder instances
  stop        Stop builder instance
  use         Set the current builder instance
  version     Show buildx version information

Run 'docker buildx COMMAND --help' for more information on a command.

Experimental commands and flags are hidden. Set BUILDX_EXPERIMENTAL=1 to show them.
ERROR: unknown command: "info"
```
