### PR TITLE
hotfix: proper `dockerPluginsDir`

### DIFF
--- a/provisioning/windows-provision.ps1
+++ b/provisioning/windows-provision.ps1
@@ -83,7 +83,7 @@ $baseDir = 'C:\tools'
 New-Item -ItemType Directory -Path $baseDir -Force | Out-Null
 
 # Special case for docker plugins
-$dockerPluginsDir = "${env:ProgramFiles}"\Docker\cli-plugins
+$dockerPluginsDir = "${0}\Docker\cli-plugins" -f $env:ProgramFiles
 New-Item -ItemType Directory -Path $dockerPluginsDir -Force | Out-Null
 
 # Ensure NuGet package provider is initialized (non-interactively)


### PR DESCRIPTION
This changes fixes the following error:
```
2026-05-04T09:15:21Z: ==&gt; amazon-ebs.windows: Provisioning with powershell script: ./provisioning/windows-provision.ps1
2026-05-04T09:15:38Z: ==&gt; amazon-ebs.windows: At C:\Windows\Temp\script-69f863a9-63e1-b209-fa8b-5a77fe0e48f4.ps1:86 char:42
2026-05-04T09:15:38Z: ==&gt; amazon-ebs.windows: + $dockerPluginsDir = "${env:ProgramFiles}"\Docker\cli-plugins
2026-05-04T09:15:38Z: ==&gt; amazon-ebs.windows: +                                          ~~~~~~~~~~~~~~~~~~~
2026-05-04T09:15:38Z: ==&gt; amazon-ebs.windows: Unexpected token '\Docker\cli-plugins' in expression or statement.
2026-05-04T09:15:38Z: ==&gt; amazon-ebs.windows:     + CategoryInfo          : ParserError: (:) [], ParseException
2026-05-04T09:15:38Z: ==&gt; amazon-ebs.windows:     + FullyQualifiedErrorId : UnexpectedToken
```

Fixup of:
- #2687

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/5088