### PR TITLE
fix(windows): add docker plugin folder to `PATH`

### DIFF
--- a/provisioning/windows-provision.ps1
+++ b/provisioning/windows-provision.ps1
@@ -289,7 +289,8 @@ $downloads['goss'] = @{
 };
 $downloads['docker-buildx'] = @{
     'url' = 'https://github.com/docker/buildx/releases/download/v{0}/buildx-v{0}.windows-amd64.exe' -f $env:DOCKER_BUILDX_VERSION;
-    'local' = "$dockerPluginsDir\docker-buildx.exe"
+    'local' = "$dockerPluginsDir\docker-buildx.exe";
+    'path' = $dockerPluginsDir;
 };
 $downloads['chocolatey-and-packages'] = @{
     'url' = 'https://github.com/chocolatey/choco/releases/download/{0}/chocolatey.{0}.nupkg' -f $env:CHOCOLATEY_VERSION;


### PR DESCRIPTION
Even with #2687, `docker buildx` is still "not found". This change adds docker plugins folder to $PATH to fix it.

Follow-up of:
- #2687
- #2697

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/5088