### PR TITLE
hotfix(windows/buildx): hardcode docker plugins path

### DIFF
--- a/provisioning/windows-provision.ps1
+++ b/provisioning/windows-provision.ps1
@@ -82,10 +82,6 @@ New-NetFirewallRule -Name sshd -DisplayName 'OpenSSH Server (sshd)' -Enabled Tru
 $baseDir = 'C:\tools'
 New-Item -ItemType Directory -Path $baseDir -Force | Out-Null
 
-# Special case for docker plugins
-$dockerPluginsDir = "${0}\Docker\cli-plugins" -f $env:ProgramFiles
-New-Item -ItemType Directory -Path $dockerPluginsDir -Force | Out-Null
-
 # Ensure NuGet package provider is initialized (non-interactively)
 Get-PackageProvider NuGet -ForceBootstrap
 
@@ -289,7 +285,7 @@ $downloads['goss'] = @{
 };
 $downloads['docker-buildx'] = @{
     'url' = 'https://github.com/docker/buildx/releases/download/v{0}/buildx-v{0}.windows-amd64.exe' -f $env:DOCKER_BUILDX_VERSION;
-    'local' = "$dockerPluginsDir\docker-buildx.exe"
+    'local' = 'C:\Program Files\Docker\cli-plugins\docker-buildx.exe'
 };
 $downloads['chocolatey-and-packages'] = @{
     'url' = 'https://github.com/chocolatey/choco/releases/download/{0}/chocolatey.{0}.nupkg' -f $env:CHOCOLATEY_VERSION;

--- a/provisioning/windows-provision.ps1
+++ b/provisioning/windows-provision.ps1
@@ -52,7 +52,7 @@ Function Retry-Command {
 }
 
 Function DownloadFile($url, $targetFile) {
-    Write-Host "Downloading $url"
+    Write-Host "Downloading $url to $targetFile"
     Retry-Command -ScriptBlock {
         $ProgressPreference = 'SilentlyContinue' # Disable Progress bar for faster downloads
         Invoke-WebRequest $url -OutFile $targetFile


### PR DESCRIPTION
Follow-up of:
- #2687
- #2697

Refs:
- https://github.com/jenkins-infra/helpdesk/issues/5088
- https://github.com/jenkins-infra/packer-images/pull/2698#issuecomment-4372158974
  > docker plugin folder isn't properly defined:
  > <img width="2332" height="588" alt="image" src="https://github.com/user-attachments/assets/b36f8eba-47d2-406b-9e69-fbbf8d1d6f37" />
