### PR TITLE
hotfix(windows/buildx): ensure docker plugins folder exists 

### DIFF
--- a/provisioning/windows-provision.ps1
+++ b/provisioning/windows-provision.ps1
@@ -82,6 +82,10 @@ New-NetFirewallRule -Name sshd -DisplayName 'OpenSSH Server (sshd)' -Enabled Tru
 $baseDir = 'C:\tools'
 New-Item -ItemType Directory -Path $baseDir -Force | Out-Null
 
+# Special case for docker plugins
+$dockerPluginsDir = 'C:\Program Files\Docker\cli-plugins'
+New-Item -ItemType Directory -Path $dockerPluginsDir -Force | Out-Null
+
 # Ensure NuGet package provider is initialized (non-interactively)
 Get-PackageProvider NuGet -ForceBootstrap
 
@@ -285,7 +289,7 @@ $downloads['goss'] = @{
 };
 $downloads['docker-buildx'] = @{
     'url' = 'https://github.com/docker/buildx/releases/download/v{0}/buildx-v{0}.windows-amd64.exe' -f $env:DOCKER_BUILDX_VERSION;
-    'local' = 'C:\Program Files\Docker\cli-plugins\docker-buildx.exe'
+    'local' = "$dockerPluginsDir\docker-buildx.exe";
 };
 $downloads['chocolatey-and-packages'] = @{
     'url' = 'https://github.com/chocolatey/choco/releases/download/{0}/chocolatey.{0}.nupkg' -f $env:CHOCOLATEY_VERSION;

--- a/provisioning/windows-provision.ps1
+++ b/provisioning/windows-provision.ps1
@@ -52,7 +52,7 @@ Function Retry-Command {
 }
 
 Function DownloadFile($url, $targetFile) {
-    Write-Host "Downloading $url to $targetFile"
+    Write-Host ("Downloading {0} to {1}" -f ($url -replace 'https://', 'https:// '), $targetFile)
     Retry-Command -ScriptBlock {
         $ProgressPreference = 'SilentlyContinue' # Disable Progress bar for faster downloads
         Invoke-WebRequest $url -OutFile $targetFile


### PR DESCRIPTION
Follow-up of:
- #2687
- #2697
- #2699 

Refs:
- https://github.com/jenkins-infra/helpdesk/issues/5088
