### PR TITLE
fix(ubuntu-provision) ensure pinned version of playwright is used for for its NPX install-deps

### DIFF
--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -590,25 +590,23 @@ function install_nodejs() {
 }
 
 function install_playwright() {
-  # Install pinned playwright globally
+  # Install for user '$username'
   su - "${username}" -c "source ${asdf_install_dir}/asdf.sh && npm install -g playwright@${PLAYWRIGHT_VERSION}"
-
-  # Install required system dependencies - https://playwright.dev/docs/browsers#install-system-dependencies
-  # Note: need to extract the list of missing packages as jenkins user but install as root
-  playwright_system_deps="$(su - "${username}" -c "\
+  
+  # The command 'npx playwright install-deps --dry-run' prints the expected command for installing dependencies.
+  # But this command requires `sudo` access (which the ${username} user does not have).
+  # Also, the `root` user does not have access to the ASDF setup.
+  playwright_deps_install_command="$(su - "${username}" -c "\
     source ${asdf_install_dir}/asdf.sh \
-    && npx playwright install-deps --dry-run \
-      | grep -v 'Missing system dependencies' `# Remove initial header line` \
-    || true `# playwright install-deps command fails if packages are missing. let's report later for diagnosing` " \
+    && npx playwright install-deps --dry-run" \
   )"
 
-  # Report in build logs
-  echo "Installing the following system dependencies for playwright:"
-  echo "${playwright_system_deps}"
+  # Report to build logs
+  echo "[Playwright] installing dependencies using the command:"
+  echo "${playwright_deps_install_command}"
   echo
-
-  # Perform the installation as root user
-  echo "${playwright_system_deps}" | xargs apt-get install -y
+  
+  eval "${playwright_deps_install_command}" 
 }
 
 ## Install Launchable with python3 in its own virtual environment

--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -590,18 +590,25 @@ function install_nodejs() {
 }
 
 function install_playwright() {
-  ### Install playwright's dependencies before the module itself
-  ## The command 'npx playwright install-deps --dry-run' prints the expectd command for installing dependencies.
-  # But this command requires `sudo` access (which the ${username} user does not have).
-  # Also, the `root` user does not have access to the ASDF setup.
-  # Don't forget to change dir and to remove any `stderr` to avoid polluting the evakuated command
-  playwright_deps_install_command="$(su - "${username}" -c "\
-    source ${asdf_install_dir}/asdf.sh \
-    && npx playwright install-deps --dry-run")"
-  eval "${playwright_deps_install_command}"
-
   # Install pinned playwright globally
   su - "${username}" -c "source ${asdf_install_dir}/asdf.sh && npm install -g playwright@${PLAYWRIGHT_VERSION}"
+
+  # Install required system dependencies - https://playwright.dev/docs/browsers#install-system-dependencies
+  # Note: need to extract the list of missing packages as jenkins user but install as root
+  playwright_system_deps="$(su - "${username}" -c "\
+    source ${asdf_install_dir}/asdf.sh \
+    && npx playwright install-deps --dry-run \
+      | grep -v 'Missing system dependencies' `# Remove initial header line` \
+    || true `# playwright install-deps command fails if packages are missing. let's report later for diagnosing` " \
+  )"
+
+  # Report in build logs
+  echo "Installing the following system dependencies for playwright:"
+  echo "${playwright_system_deps}"
+  echo
+
+  # Perform the installation as root user
+  echo "${playwright_system_deps}" | xargs apt-get install -y
 }
 
 ## Install Launchable with python3 in its own virtual environment

--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -597,8 +597,7 @@ function install_playwright() {
   # Don't forget to change dir and to remove any `stderr` to avoid polluting the evakuated command
   playwright_deps_install_command="$(su - "${username}" -c "\
     source ${asdf_install_dir}/asdf.sh \
-    && npx playwright install-deps --dry-run" \
-  2>/dev/null)"
+    && npx playwright install-deps --dry-run")"
   eval "${playwright_deps_install_command}"
 
   # Install pinned playwright globally


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/packer-images/issues/2720

- If the NPX command is called before installing a pinned version, then there could be 2 distinct versions used, which led to breaking changes without a stable behavior
- Also allows debugging by not suppressing stderr
- Also prints the "install-deps" command