### PR TITLE
chore(updatecli): update `kubectl` release line to 1.34

### DIFF
--- a/updatecli/updatecli.d/kubectl.yaml
+++ b/updatecli/updatecli.d/kubectl.yaml
@@ -26,7 +26,7 @@ sources:
       username: "{{ .github.username }}"
       versionfilter:
         kind: regex
-        pattern: "^kubernetes-1.33.(\\d*)$"
+        pattern: "^kubernetes-1.34.(\\d*)$"
 
 targets:
   updateVersion:


### PR DESCRIPTION
Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4908

This PR tracks `kubectl` v1.34.x version

Tested locally with success:

```
target: target#updateVersionInGoss
--------------------------

**Dry Run enabled**

⚠ - change detected:
        * key "$.command.kubectl.stdout[0]" should be updated from "1.33.12" to "1.34.8", in file "tests/goss-common.yaml"

```