### PR TITLE
Revert "Bump jx-release-version version to 2.9.0"

### DIFF
--- a/provisioning/tools-versions.yml
+++ b/provisioning/tools-versions.yml
@@ -24,7 +24,7 @@ helm_version: 3.19.1
 helmfile_version: 1.5.1
 jenkins_remoting_version: 3355.v388858a_47b_33
 jq_version: 1.6
-jxreleaseversion_version: 2.9.0
+jxreleaseversion_version: 2.8.4
 kubectl_version: 1.33.11
 launchable_version: 1.123.2
 maven_version: 3.9.15

--- a/tests/goss-common.yaml
+++ b/tests/goss-common.yaml
@@ -68,7 +68,7 @@ command:
     exec: jx-release-version -version
     exit-status: 0
     stdout:
-      - 2.9.0
+      - 2.8.4
   kubectl:
     exec: kubectl version --client
     exit-status: 0


### PR DESCRIPTION
Reverts jenkins-infra/packer-images#2728

Ref. https://github.com/jenkins-x-plugins/jx-release-version/issues/148