### PR TITLE
chore(updatecli): fix nuget manifest: use jq 1.6 compatible syntax in nuget version script

### DIFF
--- a/updatecli/scripts/fetch-nuget-latest-version.sh
+++ b/updatecli/scripts/fetch-nuget-latest-version.sh
@@ -10,7 +10,7 @@ set -x
 set -u
 
 nuget_dist_json="$(curl --silent --show-error --location --fail https://dist.nuget.org/index.json)"
-nuget_dist_versions="$(echo "${nuget_dist_json}" | jq -r '.artifacts.[] | select(.name == "win-x86-commandline") | .versions[].version')"
+nuget_dist_versions="$(echo "${nuget_dist_json}" | jq -r '.artifacts[] | select(.name == "win-x86-commandline") | .versions[].version')"
 found_version="$(echo "${nuget_dist_versions}" | sort -hr | head -n 1)"
 test -n "${found_version}"
 echo "${found_version}"


### PR DESCRIPTION
Ref:
- https://github.com/jenkins-infra/packer-images/pull/2733

The `updatecli/scripts/fetch-nuget-latest-version.sh` script uses `.artifacts.[]` (dot-bracket) jq syntax which requires jq 1.7+. Our CI environment runs jq 1.6,  causing the nuget version bump pipeline to fail with a compile error:

`jq: error: syntax error, unexpected '[', expecting FORMAT or QQSTRING_START`

### Fix

Replace `.artifacts.[]` with `.artifacts[]`, the standard array iteration syntax 
that works across all jq versions (1.5+).

Tested locally by running the updated filter against the live nuget dist endpoint, confirmed it returns 7.6.0. CI (which runs jq 1.6) also passes now.

```
[2026-05-15T10:56:14.054Z] ⚠ - change detected:
[2026-05-15T10:56:14.054Z] 	* key "$.nuget_version" should be updated from "7.0.3" to "7.6.0", in file "provisioning/tools-versions.yml"

```