### PR TITLE
chore(Jenkinsfile_gc) discard builds (max 200 in the history) and avoid concurent executions

### DIFF
--- a/Jenkinsfile_gc
+++ b/Jenkinsfile_gc
@@ -5,6 +5,10 @@ pipeline {
     triggers {
         cron('@hourly')
     }
+    options {
+        disableConcurrentBuilds abortPrevious: true
+        buildDiscarder logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '200')
+    }
     stages {
         stage('Garbage Collection') {
             environment {


### PR DESCRIPTION
Build discarder: ref. https://github.com/jenkins-infra/helpdesk/issues/5145#issuecomment-4575645259