### PR TITLE
chore: use `windowsserver2022` offer for Windows 2022 base images

### DIFF
--- a/build-jenkins-agent-windows.pkr.hcl
+++ b/build-jenkins-agent-windows.pkr.hcl
@@ -19,7 +19,8 @@ build {
   source "azure-arm.base" {
     name         = "windows"
     communicator = "winrm"
-    # List available offers and publishers with the command `az vm image list --output table`
+    # List available offers and publishers with the command `az vm image list --publisher MicrosoftWindowsServer --all --output table`
+    # Warnings: take quite some time; "windowsserver2022" not listed
     image_offer     = var.agent_os_version == "2022" ? "windowsserver2022" : "WindowsServer"
     image_publisher = "MicrosoftWindowsServer"
     # List available SKUs with the command `az vm image list-skus --offer WindowsServer --location eastus --publisher MicrosoftWindowsServer --output table`

--- a/build-jenkins-agent-windows.pkr.hcl
+++ b/build-jenkins-agent-windows.pkr.hcl
@@ -20,9 +20,10 @@ build {
     name         = "windows"
     communicator = "winrm"
     # List available offers and publishers with the command `az vm image list --output table`
-    image_offer     = "WindowsServer"
+    image_offer     = var.agent_os_version == "2022" ? "windowsserver2022" : "WindowsServer"
     image_publisher = "MicrosoftWindowsServer"
     # List available SKUs with the command `az vm image list-skus --offer WindowsServer --location eastus --publisher MicrosoftWindowsServer --output table`
+    # For Windows version 2022, you'll have to use `--offer windowsserver2022` (cf https://github.com/jenkins-infra/helpdesk/issues/5142)
     image_sku       = "${var.agent_os_version}-datacenter-core-g2"
     image_version   = try(local.images_versions["azure"]["windows"][var.agent_os_version][var.architecture], "N/A")
     os_type         = "Windows"


### PR DESCRIPTION
This change switches 2022 base images to the new `windowsserver2022` offer, as the ones from `windowsserver` will be deprecated and out of support after the 9th of June.
Switching to that new offer only for 2022 images, as the 2019 and the 2025 aren't available in that offer.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/5142#issuecomment-4602233811
- https://app.azure.com/h/8PJS-_48/1e73ed