### PR TITLE
cleanup: remove Chromium installation (not used by playwright anymore)

### DIFF
--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -267,29 +267,6 @@ function install_python() {
   python3 -m pip install --no-cache-dir pip --upgrade
 }
 
-## Install chromium
-### Using chromium because chrome is not available on arm64
-### see https://bugs.chromium.org/p/chromium/issues/detail?id=677140
-function install_chromium() {
-  apt-get remove --yes chromium-browser chromium-browser-l10n chromium-codecs-ffmpeg-extra
-
-  # Using this PPA as the chromium default repositories require snap which doesn't work in docker.
-  # see https://askubuntu.com/questions/1255692/is-it-still-possible-to-install-chromium-as-a-deb-package-on-20-04-lts-using-som
-  add-apt-repository --yes ppa:phd/chromium-browser
-  apt-get update --quiet
-
-  # Pin 'chromium' package to this PPA repository (to avoid chromium installed from another source)
-  # Then the candidate will always be the 18.04 package version (20.04 packages require snap but snap does not run inside Docker)
-  # Check with apt-cache policy chromium-browser
-  echo '
-Package: *
-Pin: release o=LP-PPA-phd-chromium-browser
-Pin-Priority: 1001
-' | tee /etc/apt/preferences.d/phd-chromium-browser
-
-  apt-get install --yes chromium-browser
-}
-
 ## Install git and git-lfs
 function install_git_gitlfs() {
   if [ -n "${GIT_LINUX_VERSION}" ]
@@ -698,7 +675,6 @@ function main() {
   install_goss # needed by the pipeline
   install_docker # needed by the pipeline
   install_jdks # needed by the pipeline
-  install_chromium
   install_datadog
   install_JA_requirements
   install_qemu

--- a/provisioning/windows-provision.ps1
+++ b/provisioning/windows-provision.ps1
@@ -310,7 +310,6 @@ $downloads['chocolatey-and-packages'] = @{
         Get-WindowsFeature | Where-Object Name -like "NET*" | Format-Table Name, DisplayName, InstallState -AutoSize
         # Append a ".1" as all ruby packages in chocolatey have this suffix. Not sure why (maybe a package build id)
         & "choco.exe" install ruby --yes --no-progress --limit-output --fail-on-error-output --version "${env:RUBY_VERSION}.1";
-        & "choco.exe" install chromium --yes --no-progress --limit-output --fail-on-error-output;
         & "choco.exe" install awscli --yes --no-progress --limit-output --fail-on-error-output --version "${env:AWSCLI_VERSION}";
         & "choco.exe" install datadog-agent --yes --no-progress --limit-output --fail-on-error-output;
         & "choco.exe" install vcredist2015 --yes --no-progress --limit-output --fail-on-error-output;

--- a/tests/goss-linux.yaml
+++ b/tests/goss-linux.yaml
@@ -11,9 +11,6 @@ command:
     exit-status: 0
     stdout:
       - 10.32.4
-  chromium-browser:
-    exec: chromium-browser --version
-    exit-status: 0
   datadog-agent:
     exec: datadog-agent version
     exit-status: 0

--- a/tests/goss-windows.yaml
+++ b/tests/goss-windows.yaml
@@ -80,9 +80,6 @@ command:
     stdout:
       - 'True'
 file:
-  C:\Program Files\Chromium\Application\:
-    exists: true
-    filetype: directory
   C:\Program Files\Datadog\Datadog agent\bin\:
     exists: true
     filetype: directory


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/5174

Fixes https://github.com/jenkins-infra/packer-images/issues/1883

This PR remove the Chromium installation on both Ubuntu and Windows agents. It should be replaced by Playwright webbrowser caches in a subsequent PR.