### PR TITLE
fix(ubuntu) correct playwright setup and set up headless chromium

### DIFF
--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -599,25 +599,19 @@ function install_nodejs() {
 }
 
 function install_playwright() {
-  # Install pinned playwright globally first (as NPX needs it)
-  source /etc/environment && npm install -g playwright@"${PLAYWRIGHT_VERSION}"
+  source /etc/environment
 
-  # Install required system dependencies - https://playwright.dev/docs/browsers#install-system-dependencies
-  # Note: need to extract the list of missing packages as jenkins user but install as root
-  playwright_system_deps="$(su - "${username}" -c "\
-    source ${asdf_install_dir}/asdf.sh \
-    && npx playwright install-deps --dry-run \
-      | grep -v 'Missing system dependencies' `# Remove initial header line` \
-    || true `# playwright install-deps command fails if packages are missing. let's report later for diagnosing` " \
-  )"
+  # Install pinned playwright globally first
+  npm install -g playwright@"${PLAYWRIGHT_VERSION}"
 
-  # Report in build logs
-  echo "Installing the following system dependencies for playwright:"
-  echo "${playwright_system_deps}"
-  echo
+  # Install system dependencies, must be run as root - https://playwright.dev/docs/browsers#install-system-dependencies
+  playwright install-deps
 
-  # Perform the installation as root user
-  echo "${playwright_system_deps}" | xargs apt-get install -y
+  # Install web browser(s) as jenkins (to ensure cache is in its home and reusable)
+  su - "${username}" -c "playwright install --only-shell chromium"
+
+  # Sanity checks
+  su - "${username}" -c "playwright install --list"
 }
 
 ## Install Launchable with python3 in its own virtual environment

--- a/tests/goss-linux.yaml
+++ b/tests/goss-linux.yaml
@@ -95,6 +95,12 @@ command:
     exit-status: 0
     stdout:
       - 1.60.0
+  playwright-chromium-cache:
+    exec: playwright install --list
+    exit-status: 0
+    stdout:
+      - 'chromium_headless_shell'
+      - 'ffmpeg'
   python3:
     exec: python3 --version
     exit-status: 0


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5174

This PR fixes the Playwright setup which was broken by #2775

It simplifies the setup installation by only running the "full" `install-deps` command as `root` user, instead of the former fragile stdout parsing with the `--dry-run` flag (since ASDF as `jenkins` user is not required anymore).

It also pre-installs the `chromium` headless cache as `jenkins` user (tested on a local container) to avoid requiring pipelines to run `npx playwright install` command on each run.