### PR TITLE
feat(windows) add playwright NodeJS CLI with its headless chromium cache

### DIFF
--- a/provisioning/windows-provision.ps1
+++ b/provisioning/windows-provision.ps1
@@ -63,10 +63,15 @@ Function AddToPathEnv($path) {
     $oldPath = (Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH).path
     $newPath = '{0};{1}' -f $path,$oldPath
     Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value $newPath | Out-Null
+    # Update self (script) environment
+    $env:Path = $newPath
 }
 
-# Requried by testing libraries such as playwright
-Install-WindowsFeature Server-Media-Foundation
+Function AddEnvToSystem($name, $value) {
+    New-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name $name -Value $value | Out-Null
+    # Update self (script) environment
+    Set-Item "env:$name" $value
+}
 
 # Install OpenSSH (from Windows Features)
 Write-Output "= Installing OpenSSH Server..."
@@ -88,6 +93,10 @@ New-Item -ItemType Directory -Path $dockerPluginsDir -Force | Out-Null
 
 # Ensure NuGet package provider is initialized (non-interactively)
 Get-PackageProvider NuGet -ForceBootstrap
+
+# Install .NET 3.5 (used by MSI builds)
+Install-WindowsFeature Net-Framework-Core
+Get-WindowsFeature | Where-Object Name -like "NET*" | Format-Table Name, DisplayName, InstallState -AutoSize
 
 ## List of tools to use
 $downloads = [ordered]@{}
@@ -291,6 +300,8 @@ $downloads['docker-buildx'] = @{
     'url' = 'https://github.com/docker/buildx/releases/download/v{0}/buildx-v{0}.windows-amd64.exe' -f $env:DOCKER_BUILDX_VERSION;
     'local' = "$dockerPluginsDir\docker-buildx.exe";
 };
+# Used as bin dir for NodeJS/NPM and also the NPM global packages
+$nodeJsInstallDir = "C:\Program Files\nodejs"
 $downloads['chocolatey-and-packages'] = @{
     'url' = 'https://github.com/chocolatey/choco/releases/download/{0}/chocolatey.{0}.nupkg' -f $env:CHOCOLATEY_VERSION;
     'local' = "$baseDir\chocolatey.zip";
@@ -301,19 +312,38 @@ $downloads['chocolatey-and-packages'] = @{
         & Remove-Item -Force -Recurse "$baseDir\chocolatey.tmp";
     };
     'cleanupLocal' = 'true';
-    'path' = "C:\Program Files\Amazon\AWSCLIV2";
+    'path' = "C:\Program Files\Amazon\AWSCLIV2;$nodeJsInstallDir";
     'postInstall' = {
-        # Installation of make for Windows
-        & "choco.exe" install make --yes --no-progress --limit-output --fail-on-error-output;
-        # install .NET 3.5 for MSI build
-        Install-WindowsFeature Net-Framework-Core
-        Get-WindowsFeature | Where-Object Name -like "NET*" | Format-Table Name, DisplayName, InstallState -AutoSize
+        # chocolatey internal command used to update current shell's environment. Not strictly required but we never know what bad surprise it could avoid.
+        refreshenv;
+        # Installation packages without pinned versions in one shot (faster)
+        choco install make datadog-agent vcredist2015 --yes --no-progress --limit-output --fail-on-error-output;
         # Append a ".1" as all ruby packages in chocolatey have this suffix. Not sure why (maybe a package build id)
-        & "choco.exe" install ruby --yes --no-progress --limit-output --fail-on-error-output --version "${env:RUBY_VERSION}.1";
-        & "choco.exe" install awscli --yes --no-progress --limit-output --fail-on-error-output --version "${env:AWSCLI_VERSION}";
-        & "choco.exe" install datadog-agent --yes --no-progress --limit-output --fail-on-error-output;
-        & "choco.exe" install vcredist2015 --yes --no-progress --limit-output --fail-on-error-output;
-        & "choco.exe" install nodejs.install --yes --no-progress --limit-output --fail-on-error-output --version "${env:NODEJS_WINDOWS_VERSION}";
+        choco install ruby --yes --no-progress --limit-output --fail-on-error-output --version "${env:RUBY_VERSION}.1";
+        choco install awscli --yes --no-progress --limit-output --fail-on-error-output --version "${env:AWSCLI_VERSION}";
+        choco install nodejs.install --yes --no-progress --limit-output --fail-on-error-output --version "${env:NODEJS_WINDOWS_VERSION}";
+        # Default NPM prefix dir, on Windows, is in the %AppData% of the current user so not really globally available...
+        npm config set prefix $nodeJsInstallDir;
+    };
+};
+$downloads['playwright'] = @{
+    'check' = {
+        # Check NPM is present as we need it (implies NodeJS of course)
+        npm --version;
+    }
+    'env' = @{
+        'PLAYWRIGHT_BROWSERS_PATH' = "$baseDir\playwright-cache"
+    }
+    'postInstall' = {
+        Install-WindowsFeature Server-Media-Foundation
+        # Install Playwright NodeJS CLI
+        npm install -g playwright@"${env:PLAYWRIGHT_VERSION}"
+        # Install system dependencies, must be run as root - https://playwright.dev/docs/browsers#install-system-dependencies
+        playwright install-deps
+        # Install web browser(s)
+        playwright install --only-shell chromium
+        # Sanity check
+        playwright install --list
     };
 };
 
@@ -342,6 +372,7 @@ if("2019" -eq $env:AGENT_OS_VERSION) {
     };
 }
 
+
 ## Add tools folder to PATH so we can sanity check them as soon as they are installed
 AddToPathEnv $baseDir
 
@@ -359,7 +390,9 @@ foreach($k in $downloads.Keys) {
     }
     Write-Host "Downloading and setting up $k"
 
-    DownloadFile $download['url'] $download['local']
+    if($download.ContainsKey('url')) {
+        DownloadFile $download['url'] $download['local']
+    }
 
     if($download.ContainsKey('preExpand')) {
         Invoke-Command -ScriptBlock $download['preExpand']
@@ -380,7 +413,7 @@ foreach($k in $downloads.Keys) {
     if($download.ContainsKey('env')) {
         foreach($name in $download['env'].Keys) {
             $value = $download['env'][$name]
-            New-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name $name -Value $value | Out-Null
+            AddToPathEnv $name $value
         }
     }
 

--- a/tests/goss-common.yaml
+++ b/tests/goss-common.yaml
@@ -96,6 +96,17 @@ command:
     timeout: 20000
     stdout:
       - 1.15.4
+  playwright:
+    exec: playwright --version
+    exit-status: 0
+    stdout:
+      - 1.61.0
+  playwright-chromium-cache:
+    exec: playwright install --list
+    exit-status: 0
+    stdout:
+      - 'chromium_headless_shell'
+      - 'ffmpeg'
   terraform:
     exec: terraform -v
     exit-status: 0

--- a/tests/goss-linux.yaml
+++ b/tests/goss-linux.yaml
@@ -90,17 +90,6 @@ command:
   parallel:
     exec: parallel --version
     exit-status: 0
-  playwright:
-    exec: playwright --version
-    exit-status: 0
-    stdout:
-      - 1.61.0
-  playwright-chromium-cache:
-    exec: playwright install --list
-    exit-status: 0
-    stdout:
-      - 'chromium_headless_shell'
-      - 'ffmpeg'
   python3:
     exec: python3 --version
     exit-status: 0


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5174

This PR introduces a few required changes to ensure we have the NodeJS `playwright` CLI available for Windows agents, along with its browser cache:

- Feat: add a `playwright` item in the `$downloads` Hashmap. Could have a been a simple code block **after** the iterations on the hashmap but I wanted to reuse the `env` and `check` items to express constraints in a clear way.
  - Moved the `Server-Media-Foundation` installation in this block as it's the only requirement
  - Same steps as Linux, documented in their official documentation
- Fix: make the `download` step (in the $ downloads` hashmap iterations) conditional for cases not requiring a direct download of a remote HTTP file.
  - Required to support the `playwright` installation (which uses `npm`).
- Fix: the `AddToPathEnv()` function is now appending the specified directory in the current's script environment (not only in the register) so the new path is available for subsequent commands
  - Required to ensure that `npm` is available after the NodeJS's chocolatey installation
- Feat: A new function `AddEnvToSystem` which reuses existing code (the case of `env` key in the the `$downloads` hashmap). 
  - Required to specify a system-level (e.g. available for the `jenkins` agent non admin users) environment variable `PLAYWRIGHT_BROWSERS_PATH` (ref. https://playwright.dev/java/docs/browsers#managing-browser-binaries)
- Feat: Setting up NPM prefix to the NodeJS installation directory (e.g. same location as the `nodejs.exe` and `npm.exe` binaries).
  - Required to ensure the NPM packages installed "globally" such as `playwright` are available to other users than the Administrator used here.
- Chore: Move the `Net-Framework-Core` installation out of the chocolatey code code block item (as it's unrelated. I don't know why it was here but I bet a quick `git history` would show we used to install .NET with chocolatey in the past)
- Chore: cleaned up chocolatey installation steps for easier reading and faster execution
- Tests: moved the `playwright` goss tests from Linux-only to "all OSes"


Important note: given the different techniques we use to setup a `jenkins` user agent (at least different between AWS EC2 agents and Azure VM agents), we might not have the `PLAYWRIGHT_BROWSERS_PATH` environment variable available for the users. If that is the case, I'll open PRs in the required controller JCasC setups to explicitly set this variable.