### PR TITLE
chore(updatecli): restore `jq-` prefix in goss assertion target of `jq` manifest

### DIFF
--- a/updatecli/updatecli.d/jq.yml
+++ b/updatecli/updatecli.d/jq.yml
@@ -47,7 +47,10 @@ targets:
     scmid: default
   updateJQVersionInGoss:
     name: Update the `jq` version in the goss test
+    sourceid: lastReleaseVersion
     kind: yaml
+    transformers:
+      - addprefix: "jq-"
     spec:
       files:
         - tests/goss-common.yaml


### PR DESCRIPTION
Ref:
- https://github.com/jenkins-infra/helpdesk/issues/5117

The jq.yml source trims the `jq-` prefix (correct for tools-versions.yml, which builds the download URL as jq-${JQ_VERSION}). But the goss test asserts the literal `jq --version` output, which includes the prefix (e.g. jq-1.8.1).

Add an addprefix transformer on the goss target so it writes `jq-<version>` instead of the bare version, otherwise the goss test fails on the next bump.

## Testing

`updatecli diff` confirms the goss target now renders the prefixed value:

```
target#updateJQVersionInGoss
[transformers] ✔ Result correctly transformed from "1.8.1" to "jq-1.8.1"
⚠ key "$.command.jq.stdout[0]" should be updated from "1.8.1" to "jq-1.8.1"

```
Note: this is a prerequisite fix for the jq 1.8 upgrade (#5117); the install mechanism change (Linux APT → GitHub release) follows separately so the bump can actually succeed.

