### PR TITLE
feat(ubuntu): install `python3` from source and bump to 3.14.6

### DIFF
--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -275,13 +275,12 @@ function install_python() {
   cd ..
   # cleanup
   rm -rf python-src python-src.tgz
-  apt-get remove --purge \
+  apt-get remove --purge --yes \
     build-essential \
     pkg-config \
     libssl-dev \
     zlib1g-dev \
     libmpdec-dev
-  apt-get autoremove
 }
 
 ## Install git and git-lfs

--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -259,12 +259,25 @@ function install_qemu() {
 function install_python() {
   apt-get update --quiet
   apt-get install --yes --no-install-recommends \
-    python3 \
-    python3-docker \
-    python3-pip \
-    python3-venv \
-    python3-wheel
-  python3 -m pip install --no-cache-dir pip --upgrade
+    build-essential \
+    pkg-config \
+    libssl-dev \
+    zlib1g-dev \
+    libmpdec-dev
+  mkdir python-src
+  python3_source_download_url="https://www.python.org/ftp/python/${PYTHON3_VERSION}/Python-${PYTHON3_VERSION}.tgz"
+  curl --fail --silent --show-error "${python3_source_download_url}" --output python-src.tgz
+  tar xzf python-src.tgz --strip-components=1 -C python-src
+  cd python-src
+  ./configure
+  make
+  make install
+  cd ..
+  rm -rf python-src python-src.tgz
+
+  python3 -m venv /opt/venv
+  . /opt/venv/bin/activate
+  pip install --upgrade pip
 }
 
 ## Install git and git-lfs

--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -273,11 +273,15 @@ function install_python() {
   make
   make install
   cd ..
+  # cleanup
   rm -rf python-src python-src.tgz
-
-  python3 -m venv /opt/venv
-  . /opt/venv/bin/activate
-  pip install --upgrade pip
+  apt-get remove --purge \
+    build-essential \
+    pkg-config \
+    libssl-dev \
+    zlib1g-dev \
+    libmpdec-dev
+  apt-get autoremove
 }
 
 ## Install git and git-lfs

--- a/tests/goss-common.yaml
+++ b/tests/goss-common.yaml
@@ -107,12 +107,6 @@ command:
     stdout:
       - 'chromium_headless_shell'
       - 'ffmpeg'
-  # TODO: track with updatecli
-  python3:
-    exec: python3 --version
-    exit-status: 0
-    stdout:
-      - 3.14.6
   terraform:
     exec: terraform -v
     exit-status: 0

--- a/tests/goss-common.yaml
+++ b/tests/goss-common.yaml
@@ -107,6 +107,12 @@ command:
     stdout:
       - 'chromium_headless_shell'
       - 'ffmpeg'
+  # TODO: track with updatecli
+  python3:
+    exec: python3 --version
+    exit-status: 0
+    stdout:
+      - 3.14.6
   terraform:
     exec: terraform -v
     exit-status: 0

--- a/tests/goss-linux.yaml
+++ b/tests/goss-linux.yaml
@@ -93,6 +93,9 @@ command:
   python3:
     exec: python3 --version
     exit-status: 0
+    # TODO: track with updatecli
+    stdout:
+      - 3.14.6
   rsync:
     exec: rsync --version
     exit-status: 0

--- a/tests/goss-windows.yaml
+++ b/tests/goss-windows.yaml
@@ -64,6 +64,7 @@ command:
     exit-status: 0
     stdout:
       - /7.*6.*3/
+  # Note: kept here as in Linux the binary name is `python3`
   python3:
     exec: python --version
     exit-status: 0


### PR DESCRIPTION
This change builds and installs `python3` from source so we can have the version we want (cf tool-versions).

I added the minimal amount of dev dependencies, we might need to add some later.

Ref:
- https://github.com/jenkins-infra/packer-images/issues/2837
- https://github.com/jenkins-infra/helpdesk/issues/4714