### PR TITLE
chore(pipeline): require at least one label on pull requests

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -18,6 +18,11 @@ if (env.CHANGE_ID) {
   ])
 
   lightweightMatrix = true
+
+  if (!pullRequest.labels) {
+    currentBuild.result = 'UNSTABLE'
+    exit 'At least one label required on pull requests'
+  }
 }
 
 // Initialize the packer project by installing the plugins in $PACKER_HOME_DIR/ - ref. https://www.packer.io/docs/configure
@@ -79,10 +84,6 @@ node('linux-arm64-docker') {
       ]
 
       if (env.CHANGE_ID) {
-        if (!pullRequest.labels) {
-          currentBuild.result = 'UNSTABLE'
-          exit 'At least one label required on pull requests'
-        }
         pullRequest.labels.each {
           if (it.startsWith('ubuntu-') || it.startsWith('windows-')) {
             agentTypes.add(it)

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -79,6 +79,10 @@ node('linux-arm64-docker') {
       ]
 
       if (env.CHANGE_ID) {
+        if (!pullRequest.labels) {
+          currentBuild.result = 'UNSTABLE'
+          exit 'At least one label required on pull requests'
+        }
         pullRequest.labels.each {
           if (it.startsWith('ubuntu-') || it.startsWith('windows-')) {
             agentTypes.add(it)

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -71,11 +71,7 @@ node('linux-arm64-docker') {
       ]
 
       if (env.CHANGE_ID) {
-        if (!pullRequest.labels) {
-          echo 'At least one label required on pull requests'
-          currentBuild.result = 'UNSTABLE'
-          return
-        }
+        def noLabel = true
         pullRequest.labels.each {
           if (it.startsWith('ubuntu-') || it.startsWith('windows-')) {
             agentTypes.add(it)
@@ -83,6 +79,12 @@ node('linux-arm64-docker') {
           if (it == 'linux' || it == 'windows') {
             agentTypes += agentTypeFamilies[it]
           }
+          noLabel = false
+        }
+        if (noLabel) {
+          echo 'At least one label required on pull requests'
+          currentBuild.result = 'UNSTABLE'
+          return
         }
       } else {
         agentTypes += agentTypeFamilies['linux']

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -59,14 +59,6 @@ node('linux-arm64-docker') {
       // New agent workspace specified as scripted requires an explicit checkout (compared to declarative)
       def GIT_COMMIT = checkout(scm).GIT_COMMIT
 
-      // Side Tasks stage
-      withEnv(["DRYRUN=${env.BRANCH_IS_PRIMARY ? 'false' : 'true'}"]) {
-        stage('Packer Init') {
-          // Call the initializing function once for the default agent
-          packerInitPlugins()
-        }
-      }
-
       // Conditional build depending on pull request labels
       // If there is only one type of Windows version label, build only that one
       // If there is more than one or "windows" label, build all Windows type
@@ -80,8 +72,9 @@ node('linux-arm64-docker') {
 
       if (env.CHANGE_ID) {
         if (!pullRequest.labels) {
+          echo 'At least one label required on pull requests'
           currentBuild.result = 'UNSTABLE'
-          exit 'At least one label required on pull requests'
+          return
         }
         pullRequest.labels.each {
           if (it.startsWith('ubuntu-') || it.startsWith('windows-')) {
@@ -104,6 +97,14 @@ node('linux-arm64-docker') {
       ]
 
       def matrixBranches = [:]
+
+      // Side Tasks stage
+      withEnv(["DRYRUN=${env.BRANCH_IS_PRIMARY ? 'false' : 'true'}"]) {
+        stage('Packer Init') {
+          // Call the initializing function once for the default agent
+          packerInitPlugins()
+        }
+      }
 
       matrixAxes.cpu_architecture.each { cpu_architecture ->
         matrixAxes.agent_type.each { agent_type ->

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -81,6 +81,7 @@ node('linux-arm64-docker') {
           }
           noLabel = false
         }
+        // Mark the build as unstable and exit early if the pull request doesn't have any label
         if (noLabel) {
           echo 'At least one label required on pull requests'
           currentBuild.result = 'UNSTABLE'

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -18,11 +18,6 @@ if (env.CHANGE_ID) {
   ])
 
   lightweightMatrix = true
-
-  if (!pullRequest.labels) {
-    currentBuild.result = 'UNSTABLE'
-    exit 'At least one label required on pull requests'
-  }
 }
 
 // Initialize the packer project by installing the plugins in $PACKER_HOME_DIR/ - ref. https://www.packer.io/docs/configure
@@ -84,6 +79,10 @@ node('linux-arm64-docker') {
       ]
 
       if (env.CHANGE_ID) {
+        if (!pullRequest.labels) {
+          currentBuild.result = 'UNSTABLE'
+          exit 'At least one label required on pull requests'
+        }
         pullRequest.labels.each {
           if (it.startsWith('ubuntu-') || it.startsWith('windows-')) {
             agentTypes.add(it)


### PR DESCRIPTION
This change marks a build as unstable and exits early on pull requests which don't have any label.

Follow-up of:
- #2839 

### Testing done

Build https://infra.ci.jenkins.io/job/infra-tools/job/packer-images/view/change-requests/job/PR-2843/9 marked as unstable when this PR did not have any label
