### PR TITLE
chore(tests): remove TODO comment in goss-linux.yaml

### DIFF
--- a/tests/goss-linux.yaml
+++ b/tests/goss-linux.yaml
@@ -116,7 +116,6 @@ command:
   ssh_agent:
     exec: command -v ssh-agent
     exit-status: 0
-  # TODO track with updatecli
   typos:
     exec: typos --version
     exit-status: 0


### PR DESCRIPTION
Removed TODO comment about tracking with updatecli.

Fixup of:
- #2844