### PR TITLE
fix(ubuntu): don't simlink `python3` built from source to `/usr/local/bin/python3`

### DIFF
--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -258,12 +258,20 @@ function install_qemu() {
 ## Install Python 3
 function install_python() {
   apt-get update --quiet
+  # python3-* required for python installed from Ubunbu/debian package
+  # TODO: check if we can use molecule in jenkinsci/packaging without (most of) them
   apt-get install --yes --no-install-recommends \
     build-essential \
     pkg-config \
     libssl-dev \
     zlib1g-dev \
-    libmpdec-dev
+    libmpdec-dev \
+	python3 \
+	python3-docker \
+    python3-pip \
+    python3-venv \
+    python3-wheel
+  python3 -m pip install --no-cache-dir pip --upgrade
   mkdir python-src
   python3_source_download_url="https://www.python.org/ftp/python/${PYTHON3_VERSION}/Python-${PYTHON3_VERSION}.tgz"
   curl --fail --silent --show-error "${python3_source_download_url}" --output python-src.tgz
@@ -271,7 +279,8 @@ function install_python() {
   cd python-src
   ./configure
   make
-  make install
+  # "altinstall" instead of "install" to avoid simlink of /usr/local/bin/python3.14 to /usr/local/bin/
+  make altinstall
   cd ..
   # cleanup
   rm -rf python-src python-src.tgz

--- a/tests/goss-linux.yaml
+++ b/tests/goss-linux.yaml
@@ -90,10 +90,16 @@ command:
   parallel:
     exec: parallel --version
     exit-status: 0
-  python3:
+  # Python3 installed from Ubuntu/debian package
+  python3package:
     exec: python3 --version
     exit-status: 0
-    # TODO: track with updatecli
+    stdout:
+      - "3.10"
+  # Python3 installed from source
+  python3:
+    exec: /usr/local/bin/python3.14 --version
+    exit-status: 0
     stdout:
       - 3.14.6
   rsync:


### PR DESCRIPTION
This change allows to keep both python3 installed from Ubuntu/debian package (3.10) and python3 installed from source (3.14) so I can continue tinkering and progressing on a proper installation from source with all required modules, without reverting it altogether (cf https://github.com/jenkins-infra/packer-images/pull/2847, which would also require reverting https://github.com/jenkins-infra/packer-images/pull/2844).

Refs:
- https://github.com/jenkins-infra/packer-images/pull/2838#issuecomment-4753042211
- https://github.com/jenkins-infra/packer-images/issues/2837

### Testing done

```bash
$ docker run -it --rm jenkinsciinfra/jenkins-agent-ubuntu-22.04 /bin/bash        
jenkins@8e728ee88227:~$ whereis python3
python3: /usr/bin/python3 /usr/lib/python3 /etc/python3 /usr/share/python3 /opt/az/bin/python3
jenkins@8e728ee88227:~$ python3 --version
Python 3.10.12
jenkins@8e728ee88227:~$ /usr/local/bin/python3.14 --version
Python 3.14.6
```