### PR TITLE
feat(linux): add `xmllint` and `bc`

### DIFF
--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -717,6 +717,16 @@ function install_typos() {
   rm -rf /tmp/typos.tar.gz
 }
 
+function install_xmllint() {
+  apt-get update --quiet
+  apt-get install --yes --no-install-recommends libxml2-utils
+}
+
+function install_bc() {
+  apt-get update --quiet
+  apt-get install --yes --no-install-recommends bc
+}
+
 function main() {
   check_commands
   copy_custom_scripts
@@ -766,6 +776,8 @@ function main() {
   install_yamllint
   install_rngd
   install_typos
+  install_xmllint
+  install_bc
 
   echo "== Installed packages:"
   dpkg -l

--- a/tests/goss-linux.yaml
+++ b/tests/goss-linux.yaml
@@ -16,6 +16,9 @@ command:
     exit-status: 0
     stdout:
       - 10.32.4
+  bc:
+    exec: bc --version
+    exit-status: 0
   datadog-agent:
     exec: datadog-agent version
     exit-status: 0
@@ -142,6 +145,9 @@ command:
       - 1.2.3
   yamllint:
     exec: yamllint -v
+    exit-status: 0
+  xmllint:
+    exec: xmllint --version
     exit-status: 0
   zip:
     exec: zip -v


### PR DESCRIPTION
This change adds `xmllint` and `bc`, to be used to retrieve test durations from XML files and adds them.

Needed for:
- https://github.com/jenkinsci/bom/pull/7033

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/5208