### PR TITLE
chore(ubuntu): Bump helm to 4.2.3 and fix plugin install for Helm 4

### DIFF
--- a/provisioning/tools-versions.yml
+++ b/provisioning/tools-versions.yml
@@ -21,7 +21,7 @@ hadolint_version: 2.14.0
 helm_diff_version: 3.15.10
 helm_git_version: 1.5.2
 helm_secrets_version: 4.7.7
-helm_version: 3.19.1
+helm_version: 4.2.3
 helmfile_version: 1.7.0
 jenkins_remoting_version: 3383.vc8881d4b_0e76
 jq_version: 1.8.2

--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -382,9 +382,13 @@ function install_helm(){
     "https://get.helm.sh/helm-v${HELM_VERSION}-linux-${ARCHITECTURE}.tar.gz" | \
     tar --extract --gunzip --strip-components 1 --directory="${install_dir}"/ "linux-${ARCHITECTURE}/helm"
 
-  su - "${username}" -c "helm plugin install https://github.com/databus23/helm-diff --version v${HELM_DIFF_VERSION}"
-  su - "${username}" -c "helm plugin install https://github.com/jkroepke/helm-secrets --version v${HELM_SECRETS_VERSION}"
-  su - "${username}" -c "helm plugin install https://github.com/aslafy-z/helm-git.git --version v${HELM_GIT_VERSION}"
+  # Helm 4 verifies plugin signatures on install by default; these sources are unsigned so verification is skipped.
+  su - "${username}" -c "helm plugin install https://github.com/databus23/helm-diff --version v${HELM_DIFF_VERSION} --verify=false"
+  # Helm 4 dropped all-in-one plugins, so helm-secrets is split into three packages that must be installed from their release artifacts.
+  su - "${username}" -c "helm plugin install https://github.com/jkroepke/helm-secrets/releases/download/v${HELM_SECRETS_VERSION}/secrets-${HELM_SECRETS_VERSION}.tgz --verify=false"
+  su - "${username}" -c "helm plugin install https://github.com/jkroepke/helm-secrets/releases/download/v${HELM_SECRETS_VERSION}/secrets-getter-${HELM_SECRETS_VERSION}.tgz --verify=false"
+  su - "${username}" -c "helm plugin install https://github.com/jkroepke/helm-secrets/releases/download/v${HELM_SECRETS_VERSION}/secrets-post-renderer-${HELM_SECRETS_VERSION}.tgz --verify=false"
+  su - "${username}" -c "helm plugin install https://github.com/aslafy-z/helm-git.git --version v${HELM_GIT_VERSION} --verify=false"
 }
 
 ## Ensure that`helmfile` is installed

--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -382,9 +382,9 @@ function install_helm(){
     "https://get.helm.sh/helm-v${HELM_VERSION}-linux-${ARCHITECTURE}.tar.gz" | \
     tar --extract --gunzip --strip-components 1 --directory="${install_dir}"/ "linux-${ARCHITECTURE}/helm"
 
-  # Helm 4 verifies plugin signatures on install by default; these sources are unsigned so verification is skipped.
+  # Helm 4 verifies plugin signatures on install by default; these sources are currently unsigned so verification is skipped.
   su - "${username}" -c "helm plugin install https://github.com/databus23/helm-diff --version v${HELM_DIFF_VERSION} --verify=false"
-  # Helm 4 dropped all-in-one plugins, so helm-secrets is split into three packages that must be installed from their release artifacts.
+  # Helm 4 dropped all-in-one plugins, so helm-secrets is now split into three packages
   su - "${username}" -c "helm plugin install https://github.com/jkroepke/helm-secrets/releases/download/v${HELM_SECRETS_VERSION}/secrets-${HELM_SECRETS_VERSION}.tgz --verify=false"
   su - "${username}" -c "helm plugin install https://github.com/jkroepke/helm-secrets/releases/download/v${HELM_SECRETS_VERSION}/secrets-getter-${HELM_SECRETS_VERSION}.tgz --verify=false"
   su - "${username}" -c "helm plugin install https://github.com/jkroepke/helm-secrets/releases/download/v${HELM_SECRETS_VERSION}/secrets-post-renderer-${HELM_SECRETS_VERSION}.tgz --verify=false"

--- a/tests/goss-linux.yaml
+++ b/tests/goss-linux.yaml
@@ -46,7 +46,7 @@ command:
     exec: helm version
     exit-status: 0
     stdout:
-      - 3.19.1
+      - 4.2.3
   helmfile:
     exec: helmfile --version
     exit-status: 0


### PR DESCRIPTION
ref: 
- https://github.com/jenkins-infra/helpdesk/issues/5127

Helm 4 changed two things that break the current plugin install:

- Plugin signatures are verified on install by default, so all three plugin installs now need --verify=false (the sources are unsigned).
- All-in-one plugins are no longer supported. helm-secrets is now split into secrets, secrets-getter and secrets-post-renderer, so the `helm plugin install <repo> --version` form only installs a partial, non-working plugin and the `helm secrets` command disappears.

helm-diff and helm-git still work with the repo + --version form, they just need --verify=false. helm-secrets is installed from its three release artifacts instead.

Testing:

Reproduced the current install in a clean ubuntu:22.04 container with helm 4.2.3. All three installs failed on the verification gate. 

After adding `--verify=false` to the plugins installation:

  ```
  NAME                    VERSION TYPE            APIVERSION  PROVENANCE
    diff                    3.15.10 cli/v1          legacy      unknown
    helm-git                1.5.2   getter/v1       legacy      unknown
    secrets                 4.7.7   cli/v1          v1          signed
    secrets-getter          4.7.7   getter/v1       v1          signed
    secrets-post-renderer   4.7.7   postrenderer/v1 v1          signed

    $ helm secrets --version
    4.7.7

```

Separately verified in the kubernetes-management repo that helm 4 renders charts identically to helm 3 (diffed a real cert-manager release) and that helm-diff and helm-git work under Helm 4.


