### PR TITLE
chore(windows) only run Windows update once and filter out blocking KB

### DIFF
--- a/build-jenkins-agent-windows.pkr.hcl
+++ b/build-jenkins-agent-windows.pkr.hcl
@@ -37,6 +37,13 @@ build {
 
   provisioner "windows-update" {
     only         = local.skip_on_pr_except_for_2019 ? ["skipped-on-pr"] : ["amazon-ebs.windows", "azure-arm.windows"]
+    filters = [
+      # exclude KB5007651:
+      #   Update for Windows Security platform - KB5007651 (Version 10.0.29510.1001)
+      # NB it can only be applied while the user is logged in.
+      "exclude:$_.Title -like '*KB5007651*'",
+      "include:$true",
+    ]
     pause_before = "1m"
   }
 

--- a/build-jenkins-agent-windows.pkr.hcl
+++ b/build-jenkins-agent-windows.pkr.hcl
@@ -35,17 +35,6 @@ build {
     winrm_username  = local.windows_winrm_user[var.image_type]
   }
 
-  ## Why repeating? https://github.com/rgl/packer-plugin-windows-update/issues/90#issuecomment-842569865
-  # Note that restarts are only done when required by windows updates
-  # Note: skipped on pull requests
-  provisioner "windows-update" {
-    only         = local.skip_on_pr_except_for_2019 ? ["skipped-on-pr"] : ["amazon-ebs.windows", "azure-arm.windows"]
-    pause_before = "1m"
-  }
-  provisioner "windows-update" {
-    only         = local.skip_on_pr_except_for_2019 ? ["skipped-on-pr"] : ["amazon-ebs.windows", "azure-arm.windows"]
-    pause_before = "1m"
-  }
   provisioner "windows-update" {
     only         = local.skip_on_pr_except_for_2019 ? ["skipped-on-pr"] : ["amazon-ebs.windows", "azure-arm.windows"]
     pause_before = "1m"


### PR DESCRIPTION
Working around https://github.com/jenkins-infra/packer-images/issues/2915, this PR introduces the following changes in the Windows provisioning steps:

- Only run the Windows updates once (the 3 times should not be needed anymore).
- Filter out a Windows update known as blocking as per the packer plugin's release notes

This PR seems to solve the Azure Windows 2019 problem described in #2915 at least on short term


