### PR TITLE
fix(ubuntu) symlink playwright's installed chromium to `/usr/local/bin/chromium`

### DIFF
--- a/provisioning/ubuntu-provision.sh
+++ b/provisioning/ubuntu-provision.sh
@@ -667,8 +667,18 @@ function install_playwright() {
   # Install web browser(s) as jenkins (to ensure cache is in its home and reusable)
   su - "${username}" -c "playwright install --only-shell chromium"
 
+  # Symlink chrome binary
+  chrome_binary_search_pattern='chrome*headless*shell'
+  if [ "${ARCHITECTURE}" == "arm64" ]
+  then
+    chrome_binary_search_pattern='headless*shell'
+  fi
+  chrome_binary="$(su - "${username}" -c "find ~/.cache/ms-playwright -type f -name ${chrome_binary_search_pattern}")"
+  ln -s "${chrome_binary}" /usr/local/bin/chromium
+
   # Sanity checks
   su - "${username}" -c "playwright install --list"
+  /usr/local/bin/chromium --version
 }
 
 ## Install Launchable with python3 in its own virtual environment

--- a/tests/goss-linux.yaml
+++ b/tests/goss-linux.yaml
@@ -19,6 +19,10 @@ command:
   bc:
     exec: bc --version
     exit-status: 0
+  chromium:
+    # Symlinked from playwright
+    exec: /usr/local/bin/chromium --version
+    exit-status: 0
   datadog-agent:
     exec: datadog-agent version
     exit-status: 0


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5197

Since https://github.com/jenkins-infra/packer-images/pull/2788 we do not provide a `chromium` binary in the `PATH` anymore which breaks some Selenium test cases.

This PR symlinks the chromium (headless) installation to `/usr/local/bin/chromium` and adds a sanity test in Goss to ensure we do not introduce regressions when upgrading playwright.

Note: the installed binary differs between x86_64 (amd64) and arm64 platforms