### PR TITLE
chore(pipeline) implement conditional build for packer providers when specified through PR labels

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -69,34 +69,52 @@ node('linux-arm64-docker') {
         'linux': ['ubuntu-22.04'],
         'windows': ['windows-2019', 'windows-2022', 'windows-2025'],
       ]
+      def computeTypes = []
+      def allPackerProviders = ['amazon-ebs', 'azure-arm', 'docker']
 
       if (env.CHANGE_ID) {
-        def noLabel = true
+        boolean noOSLabel = true
+        boolean noPackerProviderLabel = true
+
         pullRequest.labels.each {
           if (it.startsWith('ubuntu-') || it.startsWith('windows-')) {
             agentTypes.add(it)
+            noOSLabel = false
           }
           if (it == 'linux' || it == 'windows') {
             agentTypes += agentTypeFamilies[it]
+            noOSLabel = false
           }
-          noLabel = false
+          if (it.startsWith('packer-')) {
+            final String packerProvider = it.minus('packer-')
+            if(allPackerProviders.contains(packerProvider)) {
+              computeTypes.add(packerProvider)
+              noPackerProviderLabel = false
+            }
+          }
         }
         // Mark the build as unstable and exit early if the pull request doesn't have any label
-        if (noLabel) {
-          echo 'At least one label required on pull requests'
+        if (noOSLabel) {
+          echo 'ERROR: At least one Operating System label required on pull requests'
           currentBuild.result = 'UNSTABLE'
           return
+        }
+        // Slightly different than OSes: if no provider is specified then we build them all
+        if(noPackerProviderLabel) {
+          echo 'INFO: no packer provider label found. Building all providers.'
+          computeTypes = allPackerProviders
         }
       } else {
         agentTypes += agentTypeFamilies['linux']
         agentTypes += agentTypeFamilies['windows']
+        computeTypes = allPackerProviders
       }
 
       // Packer Images stage - Matrix implementation
       def matrixAxes = [
         cpu_architecture: ['amd64', 'arm64'],
         agent_type: agentTypes,
-        compute_type: ['amazon-ebs', 'azure-arm', 'docker']
+        compute_type: computeTypes
       ]
 
       def matrixBranches = [:]

--- a/updatecli/updatecli.d/aws-ubuntu-22-04-amd64-images.yaml
+++ b/updatecli/updatecli.d/aws-ubuntu-22-04-amd64-images.yaml
@@ -55,3 +55,4 @@ actions:
         - enhancement
         - ubuntu
         - linux
+        - packer-amazon-ebs

--- a/updatecli/updatecli.d/aws-ubuntu-22-04-arm64-images.yaml
+++ b/updatecli/updatecli.d/aws-ubuntu-22-04-arm64-images.yaml
@@ -55,3 +55,4 @@ actions:
         - enhancement
         - ubuntu
         - linux
+        - packer-amazon-ebs

--- a/updatecli/updatecli.d/aws-windows.yml
+++ b/updatecli/updatecli.d/aws-windows.yml
@@ -57,7 +57,7 @@ actions:
       description: "Update AWS AMI ID for Windows {{ $version }} AMD64"
       labels:
         - enhancement
-        - aws-windows
+        - packer-amazon-ebs
         - windows-{{ $version }}
 ...
 {{ end }}

--- a/updatecli/updatecli.d/azure-ubuntu-22-04-amd64-images.yml
+++ b/updatecli/updatecli.d/azure-ubuntu-22-04-amd64-images.yml
@@ -46,3 +46,4 @@ actions:
         - enhancement
         - ubuntu
         - linux
+        - packer-azure-arm

--- a/updatecli/updatecli.d/azure-ubuntu-22-04-arm64-images.yml
+++ b/updatecli/updatecli.d/azure-ubuntu-22-04-arm64-images.yml
@@ -46,3 +46,4 @@ actions:
         - enhancement
         - ubuntu
         - linux
+        - packer-azure-arm

--- a/updatecli/updatecli.d/azure-windows.yml
+++ b/updatecli/updatecli.d/azure-windows.yml
@@ -52,7 +52,7 @@ actions:
       description: "Update Azure images for Windows {{ $version }}"
       labels:
         - enhancement
-        - azure-windows
+        - packer-azure-arm
         - windows-{{ $version }}
 ...
 {{ end }}

--- a/updatecli/updatecli.d/docker-ubuntu-22-04-amd64-images.yml
+++ b/updatecli/updatecli.d/docker-ubuntu-22-04-amd64-images.yml
@@ -44,3 +44,4 @@ actions:
         - enhancement
         - ubuntu
         - linux
+        - packer-docker

--- a/updatecli/updatecli.d/docker-ubuntu-22-04-arm64-images.yml
+++ b/updatecli/updatecli.d/docker-ubuntu-22-04-arm64-images.yml
@@ -44,3 +44,4 @@ actions:
         - enhancement
         - ubuntu
         - linux
+        - packer-docker


### PR DESCRIPTION
Ref. #2824 

This PR implements a logic to conditionally build packer providers on pull requests based on labels:

- Dynamically retrieve the packer provider from `packer-*` labels but there is a validation. Pros: avoid "dynamic injection" from labels. Cons: needs to maintain the list in the pipeline.
- No `packer-` label means "Build all providers" (same behavior as before). Note: this is slightly different than with the `OS` labels where "no labels" means "no build".
