### PR TITLE
chore(windows) change the `pwsh` (aka. Powershell v7) installation from chocolatey to ZIP

### DIFF
--- a/provisioning/windows-provision.ps1
+++ b/provisioning/windows-provision.ps1
@@ -153,6 +153,20 @@ foreach ($jdkMajorVersion in $jdkList) {
     }
 }
 
+# Install Powershell 7 from ZIP installer (in addition to the default 5.x shipped with Windows Server)
+# Ref. https://learn.microsoft.com/en-us/powershell/scripting/install/install-powershell-on-windows?view=powershell-7.6#install-the-zip-package
+$downloads['powershell-7'] = @{
+    # We should use the 'archives' downoad system to ensure we always find older version (as the mirror download system only provide latest)
+    'url' = 'https://github.com/PowerShell/PowerShell/releases/download/v{0}/PowerShell-{0}-win-x64.zip'  -f $env:WINDOWS_PWSH_VERSION;
+    'local' = "$baseDir\powershell-7.zip";
+    'expandTo' = "${env:ProgramFiles}\PowerShell\7";
+    'path' = "${env:ProgramFiles}\PowerShell\7";
+    'cleanupLocal' = 'true';
+    'postExpand' = {
+        "${env:ProgramFiles}\PowerShell\7\pwsh.exe";
+    };
+};
+
 $pythondir = 'C:\python.{0}\tools' -f $env:PYTHON3_VERSION
 $downloads['nuget-then-python-and-launchable'] = @{
     'url' = 'https://dist.nuget.org/win-x86-commandline/v{0}/nuget.exe' -f $env:NUGET_VERSION;
@@ -424,21 +438,6 @@ foreach($k in $downloads.Keys) {
     if($download.ContainsKey('postInstall')) {
         Invoke-Command $download['postInstall']
     }
-}
-
-# Special case for Powershell, we need to make sure powershell.exe and pwsh.exe are both available
-# On Windows Server, Windows Powershell 5.1 is installed by default (powershell.exe)
-# On nanoserver, Powershell Core 7 is installed by default (pwsh.ex)
-# https://docs.microsoft.com/en-us/powershell/scripting/whats-new/migrating-from-windows-powershell-51-to-powershell-7?view=powershell-7.2#using-powershell-7-side-by-side-with-windows-powershell-51
-Write-Output "== Ensure both Windows Powershell and Powershell Core are available"
-if ((Get-Host | Select-Object Version).Version.Major -eq 5) {
-    Write-Output "= Windows Powershell already present, installing Powershell Core..."
-    Invoke-Command {& "choco.exe" install pwsh --yes --no-progress --limit-output --fail-on-error-output --version "${env:WINDOWS_PWSH_VERSION}";}
-    AddToPathEnv -path "C:\Program Files\PowerShell\7\"
-} else {
-    Write-Output "= Powershell Core already present, installing Windows Powershell..."
-    Invoke-Command {& "choco.exe" install powershell --yes --no-progress --limit-output --fail-on-error-output;}
-    AddToPathEnv -path "C:\Windows\System32\WindowsPowerShell\v1.0\"
 }
 
 ## Enabling LongPaths

--- a/updatecli/updatecli.d/pwsh.yml
+++ b/updatecli/updatecli.d/pwsh.yml
@@ -28,17 +28,12 @@ sources:
       - trimprefix: v
 
 conditions:
-  ## check for pwsh AND powershell-core as per : https://github.com/jenkins-infra/packer-images/issues/409#issuecomment-1308795902
-  checkForChocolateyPackagePWSH:
-    kind: shell
-    disablesourceinput: true # Do not pass source as argument to the command line
+  checkForZipDistribution:
+    kind: file
+    name: Check for pwsh ZIP installer attached to the GH release
+    disablesourceinput: true
     spec:
-      command: curl https://community.chocolatey.org/packages/pwsh/{{ source "lastReleaseVersion" }} --silent --show-error --location --fail --output /dev/null
-  checkForChocolateyPackagePOWERSHELLCORE:
-    kind: shell
-    disablesourceinput: true # Do not pass source as argument to the command line
-    spec:
-      command: curl https://community.chocolatey.org/packages/powershell-core/{{ source "lastReleaseVersion" }} --silent --show-error --location --fail --output /dev/null
+      file: https://github.com/PowerShell/PowerShell/releases/download/v{{ source "lastReleaseVersion" }}/PowerShell-{{ source "lastReleaseVersion" }}-win-x64.zip'
 
 targets:
   updateVersion:
@@ -74,5 +69,4 @@ actions:
       labels:
         - enhancement
         - pwsh
-        - powershell-core
         - windows


### PR DESCRIPTION
Ref. https://learn.microsoft.com/en-us/powershell/scripting/install/install-powershell-on-windows?view=powershell-7.6#install-the-zip-package

- Avoids random download errors from chocolatey (leading to MANY failing build during testing phase)
- One less requirement on chocolatey
- Cleanup dead code (we don't care about installing PowerShell Core on Nanoserver...)