### PR TITLE
Revert "fix(windows) use NodeJS LTS package with Chocolatey (#2942)"

### DIFF
--- a/provisioning/windows-provision.ps1
+++ b/provisioning/windows-provision.ps1
@@ -341,7 +341,7 @@ $downloads['chocolatey-and-packages'] = @{
         # Append a ".1" as all ruby packages in chocolatey have this suffix. Not sure why (maybe a package build id)
         choco install ruby --yes --no-progress --limit-output --fail-on-error-output --version "${env:RUBY_VERSION}.1";
         choco install awscli --yes --no-progress --limit-output --fail-on-error-output --version "${env:AWSCLI_VERSION}";
-        choco install nodejs-lts --yes --no-progress --limit-output --fail-on-error-output --version "${env:NODEJS_WINDOWS_VERSION}";
+        choco install nodejs.install --yes --no-progress --limit-output --fail-on-error-output --version "${env:NODEJS_WINDOWS_VERSION}";
         # Default NPM prefix dir, on Windows, is in the %AppData% of the current user so not really globally available...
         npm config set prefix $nodeJsInstallDir;
     };

--- a/updatecli/updatecli.d/nodejs-windows.yml
+++ b/updatecli/updatecli.d/nodejs-windows.yml
@@ -38,7 +38,7 @@ conditions:
     kind: shell
     disablesourceinput: true # Do not pass source as argument to the command line
     spec:
-      command: curl --silent --show-error --location --fail --output /dev/null https://community.chocolatey.org/packages/nodejs-lts/{{ source "lastReleaseVersion" }}
+      command: curl --silent --show-error --location --fail --output /dev/null https://community.chocolatey.org/packages/nodejs.install/{{ source "lastReleaseVersion" }}
 
 targets:
   updateVersion:


### PR DESCRIPTION
Reverts jenkins-infra/packer-images#2942 because NPM seems missing