### PR TITLE
chore(Jenkinsfile_k8s) fix deprecated (and missing) `withDockerPushCredentials` pipeline library step

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -217,7 +217,7 @@ node('linux-arm64-docker') {
                       // else we would loose the docker image
                       if (pkr_var_image_type == 'docker' && pkr_var_tag_name != null) {
                         stage('Publish all tags for Docker image') {
-                          infra.withDockerPushCredentials {
+                          infra.withContainerRegistry {
                             sh 'docker push --all-tags jenkinsciinfra/jenkins-agent-${PKR_VAR_agent_os_type}-${PKR_VAR_agent_os_version}'
                           }
                         }

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -237,7 +237,7 @@ node('linux-arm64-docker') {
       if (env.TAG_NAME != null) {
         stage('Build Docker Manifest') {
           withEnv(['agent_type=ubuntu-22.04']) {
-            infra.withDockerPushCredentials {
+            infra.withContainerRegistry {
               sh 'docker manifest create \
                   jenkinsciinfra/jenkins-agent-${agent_type}:latest \
                   --amend jenkinsciinfra/jenkins-agent-${agent_type}:arm64 \


### PR DESCRIPTION
Caused by https://github.com/jenkins-infra/pipeline-library/pull/1045

Blocks the release of https://github.com/jenkins-infra/packer-images/releases/tag/2.130.0, currently testing it with https://infra.ci.jenkins.io/job/infra-tools/job/packer-images/view/tags/job/2.130.0/5/ (replayed build)