### PR TITLE
chore(windows): add MSVC v145

### DIFF
--- a/provisioning/visualstudio.vsconfig
+++ b/provisioning/visualstudio.vsconfig
@@ -16,6 +16,7 @@
     "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
     "Microsoft.VisualStudio.ComponentGroup.VC.Tools.142.x86.x64",
     "Microsoft.VisualStudio.ComponentGroup.VC.Tools.143.x86.x64",
+    "Microsoft.VisualStudio.ComponentGroup.VC.Tools.145.x86.x64",
     "Microsoft.VisualStudio.Component.VC.Tools.ARM64",
     "Microsoft.VisualStudio.Component.VC.14.29.16.11.ARM64",
     "Microsoft.VisualStudio.Component.VC.14.44.17.14.ARM64",


### PR DESCRIPTION
This change is a prerequisite to build https://github.com/jenkinsci/winp on a Windows 2025 agent.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4954#issuecomment-5621357639